### PR TITLE
Add JaCoCo plugin to generate coverage reports. Implements #16

### DIFF
--- a/essentials/build.gradle
+++ b/essentials/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: "jacoco"
 sourceCompatibility = 1.7
 
 configurations {

--- a/essentials/build.gradle
+++ b/essentials/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
-apply plugin: "jacoco"
+apply from: '../jacoco.gradle'
+
 sourceCompatibility = 1.7
 
 configurations {

--- a/iterators/build.gradle
+++ b/iterators/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: "jacoco"
 sourceCompatibility = 1.7
 
 configurations {

--- a/iterators/build.gradle
+++ b/iterators/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
-apply plugin: "jacoco"
+apply from: '../jacoco.gradle'
+
 sourceCompatibility = 1.7
 
 configurations {

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -1,0 +1,10 @@
+apply plugin: "jacoco"
+
+jacocoTestReport {
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+}
+
+check.dependsOn jacocoTestReport

--- a/optional-testing/build.gradle
+++ b/optional-testing/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: "jacoco"
 sourceCompatibility = 1.7
 
 configurations {

--- a/optional-testing/build.gradle
+++ b/optional-testing/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
-apply plugin: "jacoco"
+apply from: '../jacoco.gradle'
+
 sourceCompatibility = 1.7
 
 configurations {

--- a/optional/build.gradle
+++ b/optional/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: "jacoco"
 sourceCompatibility = 1.7
 
 configurations {

--- a/optional/build.gradle
+++ b/optional/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
-apply plugin: "jacoco"
+apply from: '../jacoco.gradle'
+
 sourceCompatibility = 1.7
 
 configurations {


### PR DESCRIPTION
Was easier than I thought. Apparently there is nothing to configure in our simple setup.

To generate a report run
```
./gradlew clean build jacocoTestReport
```

The reports are added to the build directories of every module. Check out the `build/reports/tests/test/index.html` files.
