### PR TITLE
MockFunction for more concise Function mocking. #25

### DIFF
--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -10,6 +10,9 @@ configurations {
 apply from: '../publish.gradle'
 
 dependencies {
+    compile project(':iterators')
+    compile project(':optional')
+
     compile 'junit:junit:' + JUNIT
     compile 'org.hamcrest:hamcrest-all:' + HAMCREST
     compile 'org.mockito:mockito-core:' + MOCKITO

--- a/test-utils/src/main/java/org/dmfs/testutils/mocks/MockFunction.java
+++ b/test-utils/src/main/java/org/dmfs/testutils/mocks/MockFunction.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.testutils.mocks;
+
+import org.dmfs.iterables.ArrayIterable;
+import org.dmfs.iterables.SingletonIterable;
+import org.dmfs.iterables.composite.PairZipped;
+import org.dmfs.iterables.decorators.Filtered;
+import org.dmfs.iterators.Filter;
+import org.dmfs.iterators.Function;
+import org.dmfs.jems.pair.Pair;
+import org.dmfs.jems.pair.elementary.ValuePair;
+import org.dmfs.optional.First;
+import org.hamcrest.Matcher;
+
+import java.util.NoSuchElementException;
+
+import static org.hamcrest.CoreMatchers.sameInstance;
+
+
+/**
+ * Mock {@link Function} that can be used in tests as a convenience instead of 'manually' set up expectations for (multiple) calls.
+ * <p>
+ * It can be set up with Argument-Value {@link Pair}s so that when it is called it returns the Value from the {@link Pair} of the matching Argument.
+ * <p>
+ * For invocations with arguments that don't match any of the provided ones, it throws {@link AssertionError}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class MockFunction<Argument, Value> implements Function<Argument, Value>
+{
+    private final Iterable<Pair<Matcher<Argument>, Value>> mPairs;
+
+
+    public MockFunction(Iterable<Pair<Matcher<Argument>, Value>> pairs)
+    {
+        mPairs = pairs;
+    }
+
+
+    @SafeVarargs
+    public MockFunction(Pair<Matcher<Argument>, Value>... pairs)
+    {
+        this(new ArrayIterable<>(pairs));
+    }
+
+
+    public MockFunction(Iterable<Matcher<Argument>> args, Iterable<Value> values)
+    {
+        this(new PairZipped<>(args, values));
+    }
+
+
+    public MockFunction(Matcher<Argument> argumentMatcher, Value value)
+    {
+        this(new SingletonIterable<Pair<Matcher<Argument>, Value>>(new ValuePair<>(argumentMatcher, value)));
+    }
+
+
+    public MockFunction(Argument argument, Value value)
+    {
+        this(sameInstance(argument), value);
+    }
+
+
+    @Override
+    public Value apply(final Argument argument)
+    {
+        try
+        {
+            return new First<>(
+                    new Filtered<>(mPairs, new Filter<Pair<Matcher<Argument>, Value>>()
+                    {
+                        @Override
+                        public boolean iterate(Pair<Matcher<Argument>, Value> pair)
+                        {
+                            return pair.left().matches(argument);
+                        }
+
+                    }
+                    )).value().right();
+        }
+        catch (NoSuchElementException e)
+        {
+            throw new AssertionError("MockFunction called with unexpected argument: " + argument);
+        }
+    }
+}

--- a/test-utils/src/test/java/org/dmfs/testutils/mocks/MockFunctionTest.java
+++ b/test-utils/src/test/java/org/dmfs/testutils/mocks/MockFunctionTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.testutils.mocks;
+
+import org.dmfs.iterables.ArrayIterable;
+import org.dmfs.iterators.Function;
+import org.dmfs.jems.pair.Pair;
+import org.dmfs.jems.pair.elementary.ValuePair;
+import org.hamcrest.Matcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+/**
+ * Unit test for {@link MockFunction}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class MockFunctionTest
+{
+
+    private static final Object RES_1 = new Object();
+    private static final Object RES_2 = new Object();
+    private static final Object RES_3 = new Object();
+
+    @Rule
+    public ExpectedException mException = ExpectedException.none();
+
+
+    @Test
+    public void test_priCtorIterablePairs_matchingArgs_pass()
+    {
+        MockFunction<Integer, Object> mockFunction = new MockFunction<>(
+                new ArrayIterable<Pair<Matcher<Integer>, Object>>(
+                        new ValuePair<>(equalTo(arg(1)), RES_1),
+                        new ValuePair<>(equalTo(arg(2)), RES_2),
+                        new ValuePair<>(equalTo(arg(3)), RES_3)
+                ));
+
+        assertThat(mockFunction.apply(arg(1)), sameInstance(RES_1));
+        assertThat(mockFunction.apply(arg(2)), sameInstance(RES_2));
+        assertThat(mockFunction.apply(arg(3)), sameInstance(RES_3));
+    }
+
+
+    @Test(expected = AssertionError.class)
+    public void test_priCtorIterablePairs_differentArg_fail()
+    {
+        MockFunction<Integer, Object> mockFunction = new MockFunction<>(
+                new ArrayIterable<Pair<Matcher<Integer>, Object>>(
+                        new ValuePair<>(equalTo(arg(1)), RES_1),
+                        new ValuePair<>(equalTo(arg(2)), RES_2),
+                        new ValuePair<>(equalTo(arg(3)), RES_3)
+                ));
+
+        assertThat(mockFunction.apply(arg(1)), sameInstance(RES_1));
+        assertThat(mockFunction.apply(arg(2)), sameInstance(RES_2));
+        mockFunction.apply(arg(5));
+    }
+
+
+    @Test
+    public void test_secCtorIterablePairsVarargs_matchingArgs_pass()
+    {
+        MockFunction<Integer, Object> mockFunction = new MockFunction<>(
+                new ValuePair<>(equalTo(arg(1)), RES_1),
+                new ValuePair<>(equalTo(arg(2)), RES_2),
+                new ValuePair<>(equalTo(arg(3)), RES_3)
+        );
+
+        assertThat(mockFunction.apply(arg(1)), sameInstance(RES_1));
+        assertThat(mockFunction.apply(arg(2)), sameInstance(RES_2));
+        assertThat(mockFunction.apply(arg(3)), sameInstance(RES_3));
+    }
+
+
+    @Test
+    public void test_secCtorIterableIterable_matchingArgs_pass()
+    {
+        Function<Integer, Object> mockFunction = new MockFunction<>(
+                new ArrayIterable<>(equalTo(arg(1)), equalTo(arg(2)), equalTo(arg(3))),
+                new ArrayIterable<>(RES_1, RES_2, RES_3));
+
+        assertThat(mockFunction.apply(arg(1)), sameInstance(RES_1));
+        assertThat(mockFunction.apply(arg(2)), sameInstance(RES_2));
+        assertThat(mockFunction.apply(arg(3)), sameInstance(RES_3));
+    }
+
+
+    @Test(expected = AssertionError.class)
+    public void test_secCtorIterableIterable_differentArgs_fail()
+    {
+        Function<Integer, Object> mockFunction = new MockFunction<>(
+                new ArrayIterable<>(equalTo(arg(1)), equalTo(arg(2)), equalTo(arg(3))),
+                new ArrayIterable<>(RES_1, RES_2, RES_3));
+
+        assertThat(mockFunction.apply(arg(1)), sameInstance(RES_1));
+        mockFunction.apply(arg(555));
+    }
+
+
+    @Test
+    public void test_secCtorSingleMatcher_matchingArg_pass()
+    {
+        assertThat(new MockFunction<>(equalTo(arg(1)), RES_1).apply(arg(1)), sameInstance(RES_1));
+    }
+
+
+    @Test(expected = AssertionError.class)
+    public void test_ctorSingleMatcher_differentArg_fail()
+    {
+        new MockFunction<>(equalTo(arg(1)), RES_1).apply(arg(2));
+    }
+
+
+    @Test
+    public void test_secCtorSingle_sameInstanceArg_pass()
+    {
+        Integer arg = new Integer(1);
+        assertThat(new MockFunction<>(arg, RES_1).apply(arg), sameInstance(RES_1));
+    }
+
+
+    @Test(expected = AssertionError.class)
+    public void test_ctorSingle_equalInstanceArg_fail()
+    {
+        new MockFunction<>(arg(1), RES_1).apply(arg(1));
+    }
+
+
+    @Test
+    public void test_exceptionMessage()
+    {
+        mException.expect(AssertionError.class);
+        mException.expectMessage("unexpected argument");
+        mException.expectMessage(arg(555).toString());
+        new MockFunction<>(arg(1), RES_1).apply(arg(555));
+    }
+
+
+    // Shortcut for creating a value object:
+    private Integer arg(int value)
+    {
+        return new Integer(value);
+    }
+
+}

--- a/test-utils/src/test/java/org/dmfs/testutils/mocks/MockFunctionTest.java
+++ b/test-utils/src/test/java/org/dmfs/testutils/mocks/MockFunctionTest.java
@@ -66,16 +66,13 @@ public final class MockFunctionTest
     @Test(expected = AssertionError.class)
     public void test_priCtorIterablePairs_differentArg_fail()
     {
-        MockFunction<Integer, Object> mockFunction = new MockFunction<>(
+        new MockFunction<>(
                 new ArrayIterable<Pair<Matcher<Integer>, Object>>(
                         new ValuePair<>(equalTo(arg(1)), RES_1),
                         new ValuePair<>(equalTo(arg(2)), RES_2),
                         new ValuePair<>(equalTo(arg(3)), RES_3)
-                ));
-
-        assertThat(mockFunction.apply(arg(1)), sameInstance(RES_1));
-        assertThat(mockFunction.apply(arg(2)), sameInstance(RES_2));
-        mockFunction.apply(arg(5));
+                ))
+                .apply(arg(5));
     }
 
 
@@ -110,12 +107,10 @@ public final class MockFunctionTest
     @Test(expected = AssertionError.class)
     public void test_secCtorIterableIterable_differentArgs_fail()
     {
-        Function<Integer, Object> mockFunction = new MockFunction<>(
+        new MockFunction<>(
                 new ArrayIterable<>(equalTo(arg(1)), equalTo(arg(2)), equalTo(arg(3))),
-                new ArrayIterable<>(RES_1, RES_2, RES_3));
-
-        assertThat(mockFunction.apply(arg(1)), sameInstance(RES_1));
-        mockFunction.apply(arg(555));
+                new ArrayIterable<>(RES_1, RES_2, RES_3))
+                .apply(arg(555));
     }
 
 


### PR DESCRIPTION

Note: this is based on #24 currently (because of `ValueObject` usage).