### PR TITLE
Add `Seq` Iterator and Iterable, implements #47

### DIFF
--- a/iterators/src/main/java/org/dmfs/iterables/ArrayIterable.java
+++ b/iterators/src/main/java/org/dmfs/iterables/ArrayIterable.java
@@ -17,6 +17,7 @@
 
 package org.dmfs.iterables;
 
+import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.iterators.ArrayIterator;
 
 import java.util.Iterator;
@@ -29,7 +30,9 @@ import java.util.Iterator;
  *         The type of the iterated elements.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link Seq}
  */
+@Deprecated
 public final class ArrayIterable<T> implements Iterable<T>
 {
     private final T[] mArray;

--- a/iterators/src/main/java/org/dmfs/iterables/elementary/Seq.java
+++ b/iterators/src/main/java/org/dmfs/iterables/elementary/Seq.java
@@ -15,42 +15,34 @@
  * limitations under the License.
  */
 
-package org.dmfs.iterables.decorators;
-
-import org.dmfs.iterables.elementary.Seq;
+package org.dmfs.iterables.elementary;
 
 import java.util.Iterator;
 
 
 /**
- * An {@link Iterable} which iterates the elements of other {@link Iterable}s.
+ * {@link Iterable} sequence of values.
  *
  * @param <T>
  *         The type of the iterated elements.
  *
  * @author Marten Gajda
  */
-public final class Flattened<T> implements Iterable<T>
+public final class Seq<T> implements Iterable<T>
 {
-    private final Iterable<Iterable<T>> mIterables;
+    private final T[] mArray;
 
 
     @SafeVarargs
-    public Flattened(Iterable<T>... iterables)
+    public Seq(T... elements)
     {
-        this(new Seq<>(iterables));
-    }
-
-
-    public Flattened(Iterable<Iterable<T>> iterables)
-    {
-        mIterables = iterables;
+        mArray = elements;
     }
 
 
     @Override
     public Iterator<T> iterator()
     {
-        return new org.dmfs.iterators.decorators.Flattened<>(mIterables.iterator());
+        return new org.dmfs.iterators.elementary.Seq<>(mArray);
     }
 }

--- a/iterators/src/main/java/org/dmfs/iterators/ArrayIterator.java
+++ b/iterators/src/main/java/org/dmfs/iterators/ArrayIterator.java
@@ -17,6 +17,8 @@
 
 package org.dmfs.iterators;
 
+import org.dmfs.iterators.elementary.Seq;
+
 import java.util.Iterator;
 
 
@@ -27,7 +29,9 @@ import java.util.Iterator;
  *         The type of the values in the array.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link Seq}
  */
+@Deprecated
 public final class ArrayIterator<E> extends AbstractBaseIterator<E>
 {
     private final E[] mValue;

--- a/iterators/src/main/java/org/dmfs/iterators/decorators/Flattened.java
+++ b/iterators/src/main/java/org/dmfs/iterators/decorators/Flattened.java
@@ -18,16 +18,16 @@
 package org.dmfs.iterators.decorators;
 
 import org.dmfs.iterators.AbstractBaseIterator;
-import org.dmfs.iterators.ArrayIterator;
 import org.dmfs.iterators.EmptyIterator;
+import org.dmfs.iterators.elementary.Seq;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 
 /**
- * An {@link Iterator} that serializes the values of multiple {@link Iterable}s. This means, it iterates the elements of
- * each {@link Iterable} before moving on to the next {@link Iterable}.
+ * An {@link Iterator} that serializes the values of multiple {@link Iterable}s. This means, it iterates the elements of each {@link Iterable} before moving on
+ * to the next {@link Iterable}.
  *
  * @param <E>
  *         The type of the iterated values.
@@ -51,7 +51,7 @@ public final class Flattened<E> extends AbstractBaseIterator<E>
     @SafeVarargs
     public Flattened(final Iterable<E>... iterables)
     {
-        this(new ArrayIterator<>(iterables));
+        this(new Seq<>(iterables));
     }
 
 

--- a/iterators/src/main/java/org/dmfs/iterators/decorators/Serialized.java
+++ b/iterators/src/main/java/org/dmfs/iterators/decorators/Serialized.java
@@ -18,16 +18,16 @@
 package org.dmfs.iterators.decorators;
 
 import org.dmfs.iterators.AbstractBaseIterator;
-import org.dmfs.iterators.ArrayIterator;
 import org.dmfs.iterators.EmptyIterator;
+import org.dmfs.iterators.elementary.Seq;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 
 /**
- * An {@link Iterator} that serializes the results of other {@link Iterator}s. This means, it iterates the elements of
- * each {@link Iterator} before moving on to the next {@link Iterator}.
+ * An {@link Iterator} that serializes the results of other {@link Iterator}s. This means, it iterates the elements of each {@link Iterator} before moving on to
+ * the next {@link Iterator}.
  *
  * @param <E>
  *         The type of the iterated values.
@@ -50,13 +50,12 @@ public final class Serialized<E> extends AbstractBaseIterator<E>
     @SafeVarargs
     public Serialized(final Iterator<E>... iterators)
     {
-        this(new ArrayIterator<>(iterators));
+        this(new Seq<>(iterators));
     }
 
 
     /**
-     * Constructor of an {@link Iterator} that serializes the elements of the {@link Iterator}s iterated by the given
-     * {@link Iterator}.
+     * Constructor of an {@link Iterator} that serializes the elements of the {@link Iterator}s iterated by the given {@link Iterator}.
      *
      * @param iteratorIterator
      *         An {@link Iterator} that iterates other iterators of type &lt;E&gt;.

--- a/iterators/src/main/java/org/dmfs/iterators/elementary/Seq.java
+++ b/iterators/src/main/java/org/dmfs/iterators/elementary/Seq.java
@@ -15,42 +15,50 @@
  * limitations under the License.
  */
 
-package org.dmfs.iterables.decorators;
+package org.dmfs.iterators.elementary;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.iterators.AbstractBaseIterator;
 
 import java.util.Iterator;
 
 
 /**
- * An {@link Iterable} which iterates the elements of other {@link Iterable}s.
+ * An {@link Iterator} of a sequence of values.
  *
- * @param <T>
- *         The type of the iterated elements.
+ * @param <E>
+ *         The type of the values in the array.
  *
  * @author Marten Gajda
  */
-public final class Flattened<T> implements Iterable<T>
+public final class Seq<E> extends AbstractBaseIterator<E>
 {
-    private final Iterable<Iterable<T>> mIterables;
+    private final E[] mValue;
+    private int mNext;
 
 
+    /**
+     * Creates an {@link Iterator} which iterates all values in the given array.
+     *
+     * @param array
+     *         The array.
+     */
     @SafeVarargs
-    public Flattened(Iterable<T>... iterables)
+    public Seq(E... array)
     {
-        this(new Seq<>(iterables));
-    }
-
-
-    public Flattened(Iterable<Iterable<T>> iterables)
-    {
-        mIterables = iterables;
+        mValue = array;
     }
 
 
     @Override
-    public Iterator<T> iterator()
+    public boolean hasNext()
     {
-        return new org.dmfs.iterators.decorators.Flattened<>(mIterables.iterator());
+        return mNext < mValue.length;
+    }
+
+
+    @Override
+    public E next()
+    {
+        return mValue[mNext++];
     }
 }

--- a/iterators/src/main/java/org/dmfs/iterators/utils/SlimSet.java
+++ b/iterators/src/main/java/org/dmfs/iterators/utils/SlimSet.java
@@ -17,11 +17,11 @@
 
 package org.dmfs.iterators.utils;
 
-import org.dmfs.iterators.ArrayIterator;
 import org.dmfs.iterators.EmptyIterator;
 import org.dmfs.iterators.SingletonIterator;
 import org.dmfs.iterators.decorators.Filtered;
 import org.dmfs.iterators.decorators.Serialized;
+import org.dmfs.iterators.elementary.Seq;
 import org.dmfs.iterators.filters.NonNull;
 
 import java.util.Collection;
@@ -31,8 +31,8 @@ import java.util.Set;
 
 
 /**
- * An open addressing {@link Set} implementation. While insert performance is mostly comparable to the default {@link
- * HashSet} implementation, this set aims to be much more memory efficient.
+ * An open addressing {@link Set} implementation. While insert performance is mostly comparable to the default {@link HashSet} implementation, this set aims to
+ * be much more memory efficient.
  * <p>
  * This class is not thread safe.
  *
@@ -91,8 +91,8 @@ public final class SlimSet<E> implements Set<E>, Cloneable
 
 
     /**
-     * Constructor to create a set that can take at least the given number of elements before it needs to be rehashed.
-     * This constructor also allows to specify the load factor of the set.
+     * Constructor to create a set that can take at least the given number of elements before it needs to be rehashed. This constructor also allows to specify
+     * the load factor of the set.
      *
      * @param size
      *         The number of elements that the set can hold before it needs to be resized and rehashed.
@@ -245,8 +245,8 @@ public final class SlimSet<E> implements Set<E>, Cloneable
 
 
     /**
-     * Calculates the position of the given element in the given array. The value at the calculated position will be
-     * <code>null</code> if the element doesn't exist in the array, otherwise the position will point to the element.
+     * Calculates the position of the given element in the given array. The value at the calculated position will be <code>null</code> if the element doesn't
+     * exist in the array, otherwise the position will point to the element.
      *
      * @param array
      * @param object
@@ -330,7 +330,7 @@ public final class SlimSet<E> implements Set<E>, Cloneable
             return new SingletonIterator<E>(null);
         }
 
-        Iterator<E> result = new Filtered<E>(new ArrayIterator<E>((E[]) mArray.clone()),
+        Iterator<E> result = new Filtered<E>(new Seq<E>((E[]) mArray.clone()),
                 NonNull.<E>instance());
         if (mContainsNull)
         {

--- a/iterators/src/test/java/org/dmfs/iterables/composite/PairZippedTest.java
+++ b/iterators/src/test/java/org/dmfs/iterables/composite/PairZippedTest.java
@@ -17,8 +17,8 @@
 
 package org.dmfs.iterables.composite;
 
-import org.dmfs.iterables.ArrayIterable;
 import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.jems.pair.Pair;
 import org.dmfs.jems.pair.elementary.ValuePair;
 import org.hamcrest.Description;
@@ -44,12 +44,12 @@ public final class PairZippedTest
     public void test()
     {
         assertThat(new PairZipped<>(EmptyIterable.<String>instance(), EmptyIterable.<String>instance()), emptyIterable());
-        assertThat(new PairZipped<>(new ArrayIterable<>("1", "2", "3"), EmptyIterable.<String>instance()), emptyIterable());
-        assertThat(new PairZipped<>(EmptyIterable.<String>instance(), new ArrayIterable<>("a", "b", "c")), emptyIterable());
+        assertThat(new PairZipped<>(new Seq<>("1", "2", "3"), EmptyIterable.<String>instance()), emptyIterable());
+        assertThat(new PairZipped<>(EmptyIterable.<String>instance(), new Seq<>("a", "b", "c")), emptyIterable());
 
-        assertThat(new PairZipped<>(new ArrayIterable<>("1"), new ArrayIterable<>("a", "b", "c")), contains(isPair("1", "a")));
-        assertThat(new PairZipped<>(new ArrayIterable<>("1", "2", "3"), new ArrayIterable<>("a")), contains(isPair("1", "a")));
-        assertThat(new PairZipped<>(new ArrayIterable<>("1", "2", "3"), new ArrayIterable<>("a", "b", "c")),
+        assertThat(new PairZipped<>(new Seq<>("1"), new Seq<>("a", "b", "c")), contains(isPair("1", "a")));
+        assertThat(new PairZipped<>(new Seq<>("1", "2", "3"), new Seq<>("a")), contains(isPair("1", "a")));
+        assertThat(new PairZipped<>(new Seq<>("1", "2", "3"), new Seq<>("a", "b", "c")),
                 contains(isPair("1", "a"), isPair("2", "b"), isPair("3", "c")));
     }
 

--- a/iterators/src/test/java/org/dmfs/iterables/composite/ZippedTest.java
+++ b/iterators/src/test/java/org/dmfs/iterables/composite/ZippedTest.java
@@ -17,8 +17,8 @@
 
 package org.dmfs.iterables.composite;
 
-import org.dmfs.iterables.ArrayIterable;
 import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.jems.function.BiFunction;
 import org.junit.Test;
 
@@ -36,12 +36,12 @@ public class ZippedTest
     public void testIterator() throws Exception
     {
         assertThat(new Zipped<>(EmptyIterable.<String>instance(), EmptyIterable.<String>instance(), new TestFunction()), emptyIterable());
-        assertThat(new Zipped<>(new ArrayIterable<>("1", "2", "3"), EmptyIterable.<String>instance(), new TestFunction()), emptyIterable());
-        assertThat(new Zipped<>(EmptyIterable.<String>instance(), new ArrayIterable<>("a", "b", "c"), new TestFunction()), emptyIterable());
+        assertThat(new Zipped<>(new Seq<>("1", "2", "3"), EmptyIterable.<String>instance(), new TestFunction()), emptyIterable());
+        assertThat(new Zipped<>(EmptyIterable.<String>instance(), new Seq<>("a", "b", "c"), new TestFunction()), emptyIterable());
 
-        assertThat(new Zipped<>(new ArrayIterable<>("1"), new ArrayIterable<>("a", "b", "c"), new TestFunction()), contains("1a"));
-        assertThat(new Zipped<>(new ArrayIterable<>("1", "2", "3"), new ArrayIterable<>("a"), new TestFunction()), contains("1a"));
-        assertThat(new Zipped<>(new ArrayIterable<>("1", "2", "3"), new ArrayIterable<>("a", "b", "c"), new TestFunction()), contains("1a", "2b", "3c"));
+        assertThat(new Zipped<>(new Seq<>("1"), new Seq<>("a", "b", "c"), new TestFunction()), contains("1a"));
+        assertThat(new Zipped<>(new Seq<>("1", "2", "3"), new Seq<>("a"), new TestFunction()), contains("1a"));
+        assertThat(new Zipped<>(new Seq<>("1", "2", "3"), new Seq<>("a", "b", "c"), new TestFunction()), contains("1a", "2b", "3c"));
     }
 
 

--- a/iterators/src/test/java/org/dmfs/iterables/elementary/SeqTest.java
+++ b/iterators/src/test/java/org/dmfs/iterables/elementary/SeqTest.java
@@ -15,35 +15,26 @@
  * limitations under the License.
  */
 
-package org.dmfs.optional.iterable;
+package org.dmfs.iterables.elementary;
 
-import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Present;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import java.util.List;
-
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.emptyIterableOf;
 import static org.junit.Assert.assertThat;
 
 
 /**
- * Test {@link OptionalIterable}.
- *
- * @author Marten Gajda
+ * @author marten
  */
-public class OptionalIterableTest
+public class SeqTest
 {
     @Test
     public void testIterator() throws Exception
     {
-        assertThat(new OptionalIterable<>(Absent.<List<String>>absent()), emptyIterable());
-        assertThat(new OptionalIterable<>(new Present<>(new Seq<>())), Matchers.emptyIterable());
-        assertThat(new OptionalIterable<>(new Present<>(new Seq<>("1"))), contains("1"));
-        assertThat(new OptionalIterable<>(new Present<>(new Seq<>("1", "2"))), contains("1", "2"));
+        assertThat(new Seq<String>(), emptyIterableOf(String.class));
+        assertThat(new Seq<>("1"), contains("1"));
+        assertThat(new Seq<>("1", "2", "3"), contains("1", "2", "3"));
     }
 
 }

--- a/iterators/src/test/java/org/dmfs/iterators/SerialIterableIteratorTest.java
+++ b/iterators/src/test/java/org/dmfs/iterators/SerialIterableIteratorTest.java
@@ -17,6 +17,7 @@
 
 package org.dmfs.iterators;
 
+import org.dmfs.iterators.elementary.Seq;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,32 +47,32 @@ public class SerialIterableIteratorTest
 
         // trivial case, only one iterator
         assertIterateSame(list1.iterator(),
-                new SerialIterableIterator<String>(new ArrayIterator<Iterable<String>>(list1)));
+                new SerialIterableIterator<String>(new Seq<Iterable<String>>(list1)));
 
         // test various combinations of empty and non-empty iterators
         assertIterateSame(Arrays.asList("1", "2", "3", "4", "1", "2", "3", "4").iterator(),
                 new SerialIterableIterator<String>(
-                        new ArrayIterator<Iterable<String>>(list1, list1)));
+                        new Seq<Iterable<String>>(list1, list1)));
         assertIterateSame(Arrays.asList(
                 "1", "2", "3", "4", "a", "b", "c", "d", "1", "2", "3", "4", "a", "b", "c", "d")
                         .iterator(),
-                new SerialIterableIterator<String>(new ArrayIterator<Iterable<String>>(list1, list2, list1, list2)));
+                new SerialIterableIterator<String>(new Seq<Iterable<String>>(list1, list2, list1, list2)));
 
         assertIterateSame(Arrays.asList("1", "2", "3", "4", "a", "b", "c", "d").iterator(),
                 new SerialIterableIterator<String>(
-                        new ArrayIterator<Iterable<String>>(emptyStringList, list1, list2)));
+                        new Seq<Iterable<String>>(emptyStringList, list1, list2)));
 
         assertIterateSame(Arrays.asList("1", "2", "3", "4", "a", "b", "c", "d").iterator(),
                 new SerialIterableIterator<String>(
-                        new ArrayIterator<Iterable<String>>(list1, emptyStringList, list2)));
+                        new Seq<Iterable<String>>(list1, emptyStringList, list2)));
 
         assertIterateSame(Arrays.asList("1", "2", "3", "4", "a", "b", "c", "d").iterator(),
                 new SerialIterableIterator<String>(
-                        new ArrayIterator<Iterable<String>>(list1, list2, emptyStringList)));
+                        new Seq<Iterable<String>>(list1, list2, emptyStringList)));
 
         assertIterateSame(Arrays.asList("a", "b", "c", "d", "1", "2", "3", "4").iterator(),
                 new SerialIterableIterator<String>(
-                        new ArrayIterator<Iterable<String>>(list2, list1, emptyStringList)));
+                        new Seq<Iterable<String>>(list2, list1, emptyStringList)));
     }
 
 

--- a/iterators/src/test/java/org/dmfs/iterators/SerialIteratorIteratorTest.java
+++ b/iterators/src/test/java/org/dmfs/iterators/SerialIteratorIteratorTest.java
@@ -17,6 +17,7 @@
 
 package org.dmfs.iterators;
 
+import org.dmfs.iterators.elementary.Seq;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,37 +47,37 @@ public class SerialIteratorIteratorTest
 
         // trivial case, only one iterator
         assertIterateSame(list1.iterator(),
-                new SerialIteratorIterator<String>(new ArrayIterator<Iterator<String>>(list1.iterator())));
+                new SerialIteratorIterator<String>(new Seq<Iterator<String>>(list1.iterator())));
 
         // test various combinations of empty and non-empty iterators
         assertIterateSame(Arrays.asList("1", "2", "3", "4", "1", "2", "3", "4").iterator(),
                 new SerialIteratorIterator<String>(
-                        new ArrayIterator<Iterator<String>>(list1.iterator(), list1.iterator())));
+                        new Seq<Iterator<String>>(list1.iterator(), list1.iterator())));
         assertIterateSame(Arrays.asList(
                 "1", "2", "3", "4", "a", "b", "c", "d", "1", "2", "3", "4", "a", "b", "c", "d")
                         .iterator(),
                 new SerialIteratorIterator<String>(
-                        new ArrayIterator<Iterator<String>>(list1.iterator(), list2.iterator(), list1.iterator(),
+                        new Seq<Iterator<String>>(list1.iterator(), list2.iterator(), list1.iterator(),
                                 list2.iterator())));
 
         assertIterateSame(Arrays.asList("1", "2", "3", "4", "a", "b", "c", "d").iterator(),
                 new SerialIteratorIterator<String>(
-                        new ArrayIterator<Iterator<String>>(emptyStringList.iterator(), list1.iterator(),
+                        new Seq<Iterator<String>>(emptyStringList.iterator(), list1.iterator(),
                                 list2.iterator())));
 
         assertIterateSame(Arrays.asList("1", "2", "3", "4", "a", "b", "c", "d").iterator(),
                 new SerialIteratorIterator<String>(
-                        new ArrayIterator<Iterator<String>>(list1.iterator(), emptyStringList.iterator(),
+                        new Seq<Iterator<String>>(list1.iterator(), emptyStringList.iterator(),
                                 list2.iterator())));
 
         assertIterateSame(Arrays.asList("1", "2", "3", "4", "a", "b", "c", "d").iterator(),
                 new SerialIteratorIterator<String>(
-                        new ArrayIterator<Iterator<String>>(list1.iterator(), list2.iterator(),
+                        new Seq<Iterator<String>>(list1.iterator(), list2.iterator(),
                                 emptyStringList.iterator())));
 
         assertIterateSame(Arrays.asList("a", "b", "c", "d", "1", "2", "3", "4").iterator(),
                 new SerialIteratorIterator<String>(
-                        new ArrayIterator<Iterator<String>>(list2.iterator(), list1.iterator(),
+                        new Seq<Iterator<String>>(list2.iterator(), list1.iterator(),
                                 emptyStringList.iterator())));
     }
 

--- a/iterators/src/test/java/org/dmfs/iterators/composite/PairZippedTest.java
+++ b/iterators/src/test/java/org/dmfs/iterators/composite/PairZippedTest.java
@@ -17,8 +17,8 @@
 
 package org.dmfs.iterators.composite;
 
-import org.dmfs.iterators.ArrayIterator;
 import org.dmfs.iterators.EmptyIterator;
+import org.dmfs.iterators.elementary.Seq;
 import org.dmfs.jems.pair.Pair;
 import org.dmfs.jems.pair.elementary.ValuePair;
 import org.hamcrest.Description;
@@ -47,14 +47,14 @@ public final class PairZippedTest
     public void test()
     {
         assertThat(new PairZipped<>(EmptyIterator.<String>instance(), EmptyIterator.<String>instance()), IsEmptyIterator.<Pair<String, String>>emptyIterator());
-        assertThat(new PairZipped<>(new ArrayIterator<>("1", "2", "3"), EmptyIterator.<String>instance()),
+        assertThat(new PairZipped<>(new Seq<>("1", "2", "3"), EmptyIterator.<String>instance()),
                 IsEmptyIterator.<Pair<String, String>>emptyIterator());
-        assertThat(new PairZipped<>(EmptyIterator.<String>instance(), new ArrayIterator<>("a", "b", "c")),
+        assertThat(new PairZipped<>(EmptyIterator.<String>instance(), new Seq<>("a", "b", "c")),
                 IsEmptyIterator.<Pair<String, String>>emptyIterator());
 
-        assertThat(new PairZipped<>(new ArrayIterator<>("1"), new ArrayIterator<>("a", "b", "c")), contains(isPair("1", "a")));
-        assertThat(new PairZipped<>(new ArrayIterator<>("1", "2", "3"), new ArrayIterator<>("a")), contains(isPair("1", "a")));
-        assertThat(new PairZipped<>(new ArrayIterator<>("1", "2", "3"), new ArrayIterator<>("a", "b", "c")),
+        assertThat(new PairZipped<>(new Seq<>("1"), new Seq<>("a", "b", "c")), contains(isPair("1", "a")));
+        assertThat(new PairZipped<>(new Seq<>("1", "2", "3"), new Seq<>("a")), contains(isPair("1", "a")));
+        assertThat(new PairZipped<>(new Seq<>("1", "2", "3"), new Seq<>("a", "b", "c")),
                 contains(isPair("1", "a"), isPair("2", "b"), isPair("3", "c")));
     }
 

--- a/iterators/src/test/java/org/dmfs/iterators/elementary/SeqTest.java
+++ b/iterators/src/test/java/org/dmfs/iterators/elementary/SeqTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.iterators.elementary;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+
+/**
+ * @author marten
+ */
+public class SeqTest
+{
+
+    @Test
+    public void test()
+    {
+        List<String> emptyList = Arrays.asList(new String[] {});
+        List<String> list1 = Arrays.asList("1");
+        List<String> list2 = Arrays.asList("a", "1", "3");
+        List<String> list3 = Arrays.asList("a", "1", null, "3");
+
+        assertIterateSame(emptyList.iterator(), new Seq<String>());
+        assertIterateSame(list1.iterator(), new Seq<>("1"));
+        assertIterateSame(list2.iterator(), new Seq<>("a", "1", "3"));
+        assertIterateSame(list3.iterator(), new Seq<>("a", "1", null, "3"));
+
+        assertIterateSame(list1.iterator(), new Seq<>("1"));
+        assertIterateSame(list2.iterator(), new Seq<>("a", "1", "3"));
+        assertIterateSame(list3.iterator(), new Seq<>("a", "1", null, "3"));
+    }
+
+
+    /**
+     * Assert that two iterators return equal results.
+     *
+     * @param iterator1
+     * @param iterator2
+     */
+    private <E> void assertIterateSame(Iterator<E> iterator1, Iterator<E> iterator2)
+    {
+        while (iterator1.hasNext())
+        {
+            assertEquals(iterator1.next(), iterator2.next());
+        }
+
+        assertFalse(iterator2.hasNext());
+    }
+}

--- a/jems-testing/src/main/java/org/dmfs/jems/mocks/MockFunction.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/mocks/MockFunction.java
@@ -17,10 +17,10 @@
 
 package org.dmfs.jems.mocks;
 
-import org.dmfs.iterables.ArrayIterable;
 import org.dmfs.iterables.SingletonIterable;
 import org.dmfs.iterables.composite.PairZipped;
 import org.dmfs.iterables.decorators.Filtered;
+import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.iterators.Filter;
 import org.dmfs.iterators.Function;
 import org.dmfs.jems.pair.Pair;
@@ -56,7 +56,7 @@ public final class MockFunction<Argument, Value> implements Function<Argument, V
     @SafeVarargs
     public MockFunction(Pair<Matcher<Argument>, Value>... pairs)
     {
-        this(new ArrayIterable<>(pairs));
+        this(new Seq<>(pairs));
     }
 
 

--- a/jems-testing/src/test/java/org/dmfs/jems/mocks/MockFunctionTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/mocks/MockFunctionTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.mocks;
 
-import org.dmfs.iterables.ArrayIterable;
+import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.iterators.Function;
 import org.dmfs.jems.pair.Pair;
 import org.dmfs.jems.pair.elementary.ValuePair;
@@ -51,7 +51,7 @@ public final class MockFunctionTest
     public void test_priCtorIterablePairs_matchingArgs_pass()
     {
         MockFunction<Integer, Object> mockFunction = new MockFunction<>(
-                new ArrayIterable<Pair<Matcher<Integer>, Object>>(
+                new Seq<Pair<Matcher<Integer>, Object>>(
                         new ValuePair<>(equalTo(arg(1)), RES_1),
                         new ValuePair<>(equalTo(arg(2)), RES_2),
                         new ValuePair<>(equalTo(arg(3)), RES_3)
@@ -67,7 +67,7 @@ public final class MockFunctionTest
     public void test_priCtorIterablePairs_differentArg_fail()
     {
         new MockFunction<>(
-                new ArrayIterable<Pair<Matcher<Integer>, Object>>(
+                new Seq<Pair<Matcher<Integer>, Object>>(
                         new ValuePair<>(equalTo(arg(1)), RES_1),
                         new ValuePair<>(equalTo(arg(2)), RES_2),
                         new ValuePair<>(equalTo(arg(3)), RES_3)
@@ -95,8 +95,8 @@ public final class MockFunctionTest
     public void test_secCtorIterableIterable_matchingArgs_pass()
     {
         Function<Integer, Object> mockFunction = new MockFunction<>(
-                new ArrayIterable<>(equalTo(arg(1)), equalTo(arg(2)), equalTo(arg(3))),
-                new ArrayIterable<>(RES_1, RES_2, RES_3));
+                new Seq<>(equalTo(arg(1)), equalTo(arg(2)), equalTo(arg(3))),
+                new Seq<>(RES_1, RES_2, RES_3));
 
         assertThat(mockFunction.apply(arg(1)), sameInstance(RES_1));
         assertThat(mockFunction.apply(arg(2)), sameInstance(RES_2));
@@ -108,8 +108,8 @@ public final class MockFunctionTest
     public void test_secCtorIterableIterable_differentArgs_fail()
     {
         new MockFunction<>(
-                new ArrayIterable<>(equalTo(arg(1)), equalTo(arg(2)), equalTo(arg(3))),
-                new ArrayIterable<>(RES_1, RES_2, RES_3))
+                new Seq<>(equalTo(arg(1)), equalTo(arg(2)), equalTo(arg(3))),
+                new Seq<>(RES_1, RES_2, RES_3))
                 .apply(arg(555));
     }
 

--- a/optional/src/main/java/org/dmfs/optional/iterable/PresentValues.java
+++ b/optional/src/main/java/org/dmfs/optional/iterable/PresentValues.java
@@ -17,7 +17,8 @@
 
 package org.dmfs.optional.iterable;
 
-import org.dmfs.iterables.ArrayIterable;
+import org.dmfs.iterables.SingletonIterable;
+import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.optional.Optional;
 
 import java.util.Iterator;
@@ -36,15 +37,14 @@ public final class PresentValues<E> implements Iterable<E>
 
     public PresentValues(Optional<E> optional)
     {
-        // TODO: replace with `SingletonIterable` once available
-        this(new ArrayIterable<>(optional));
+        this(new SingletonIterable<>(optional));
     }
 
 
     @SafeVarargs
     public PresentValues(Optional<E>... optionals)
     {
-        this(new ArrayIterable<>(optionals));
+        this(new Seq<>(optionals));
     }
 
 

--- a/optional/src/main/java/org/dmfs/optional/iterator/PresentValues.java
+++ b/optional/src/main/java/org/dmfs/optional/iterator/PresentValues.java
@@ -18,10 +18,10 @@
 package org.dmfs.optional.iterator;
 
 import org.dmfs.iterators.AbstractBaseIterator;
-import org.dmfs.iterators.ArrayIterator;
 import org.dmfs.iterators.Filter;
 import org.dmfs.iterators.SingletonIterator;
 import org.dmfs.iterators.decorators.Filtered;
+import org.dmfs.iterators.elementary.Seq;
 import org.dmfs.optional.Optional;
 
 import java.util.Iterator;
@@ -47,7 +47,7 @@ public final class PresentValues<E> extends AbstractBaseIterator<E>
     @SafeVarargs
     public PresentValues(Optional<E>... optionals)
     {
-        this(new ArrayIterator<>(optionals));
+        this(new Seq<>(optionals));
     }
 
 

--- a/optional/src/test/java/org/dmfs/optional/adapters/FirstPresentTest.java
+++ b/optional/src/test/java/org/dmfs/optional/adapters/FirstPresentTest.java
@@ -17,11 +17,11 @@
 
 package org.dmfs.optional.adapters;
 
-import org.dmfs.iterables.ArrayIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;
 import org.dmfs.optional.Present;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.PresentMatcher.isPresent;
@@ -42,16 +42,16 @@ public final class FirstPresentTest
     @Test
     public void testVariousCases()
     {
-        assertThat(new FirstPresent<>(new ArrayIterable<Optional<String>>()), AbsentMatcher.<String>isAbsent());
+        assertThat(new FirstPresent<>(new Seq<Optional<String>>()), AbsentMatcher.<String>isAbsent());
 
-        assertThat(new FirstPresent<>(new ArrayIterable<Optional<String>>(ABSENT)), AbsentMatcher.<String>isAbsent());
-        assertThat(new FirstPresent<>(new ArrayIterable<Optional<String>>(ABSENT, ABSENT)), AbsentMatcher.<String>isAbsent());
+        assertThat(new FirstPresent<>(new Seq<Optional<String>>(ABSENT)), AbsentMatcher.<String>isAbsent());
+        assertThat(new FirstPresent<>(new Seq<Optional<String>>(ABSENT, ABSENT)), AbsentMatcher.<String>isAbsent());
 
-        assertThat(new FirstPresent<>(new ArrayIterable<Optional<String>>(new Present<>("1"))), isPresent("1"));
-        assertThat(new FirstPresent<>(new ArrayIterable<Optional<String>>(ABSENT, new Present<>("1"))), isPresent("1"));
-        assertThat(new FirstPresent<>(new ArrayIterable<Optional<String>>(new Present<>("1"), ABSENT)), isPresent("1"));
+        assertThat(new FirstPresent<>(new Seq<Optional<String>>(new Present<>("1"))), isPresent("1"));
+        assertThat(new FirstPresent<>(new Seq<Optional<String>>(ABSENT, new Present<>("1"))), isPresent("1"));
+        assertThat(new FirstPresent<>(new Seq<Optional<String>>(new Present<>("1"), ABSENT)), isPresent("1"));
 
-        assertThat(new FirstPresent<>(new ArrayIterable<Optional<String>>(new Present<>("1"), new Present<>("2"))), isPresent("1"));
+        assertThat(new FirstPresent<>(new Seq<Optional<String>>(new Present<>("1"), new Present<>("2"))), isPresent("1"));
     }
 
 }

--- a/optional/src/test/java/org/dmfs/optional/adapters/NextPresentTest.java
+++ b/optional/src/test/java/org/dmfs/optional/adapters/NextPresentTest.java
@@ -17,11 +17,11 @@
 
 package org.dmfs.optional.adapters;
 
-import org.dmfs.iterators.ArrayIterator;
+import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;
 import org.dmfs.optional.Present;
-import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.junit.Test;
 
 import java.util.Iterator;
@@ -44,31 +44,31 @@ public final class NextPresentTest
     @Test
     public void testVariousCases()
     {
-        assertThat(new NextPresent<>(new ArrayIterator<Optional<String>>()), AbsentMatcher.<String>isAbsent());
+        assertThat(new NextPresent<>(new Seq<Optional<String>>()), AbsentMatcher.<String>isAbsent());
 
-        assertThat(new NextPresent<>(new ArrayIterator<Optional<String>>(ABSENT)), AbsentMatcher.<String>isAbsent());
-        assertThat(new NextPresent<>(new ArrayIterator<Optional<String>>(ABSENT, ABSENT)), AbsentMatcher.<String>isAbsent());
+        assertThat(new NextPresent<>(new Seq<Optional<String>>(ABSENT)), AbsentMatcher.<String>isAbsent());
+        assertThat(new NextPresent<>(new Seq<Optional<String>>(ABSENT, ABSENT)), AbsentMatcher.<String>isAbsent());
 
-        assertThat(new NextPresent<>(new ArrayIterator<Optional<String>>(new Present<>("1"))), isPresent("1"));
-        assertThat(new NextPresent<>(new ArrayIterator<Optional<String>>(ABSENT, new Present<>("1"))), isPresent("1"));
-        assertThat(new NextPresent<>(new ArrayIterator<Optional<String>>(new Present<>("1"), ABSENT)), isPresent("1"));
+        assertThat(new NextPresent<>(new Seq<Optional<String>>(new Present<>("1"))), isPresent("1"));
+        assertThat(new NextPresent<>(new Seq<Optional<String>>(ABSENT, new Present<>("1"))), isPresent("1"));
+        assertThat(new NextPresent<>(new Seq<Optional<String>>(new Present<>("1"), ABSENT)), isPresent("1"));
 
-        assertThat(new NextPresent<>(new ArrayIterator<Optional<String>>(new Present<>("1"), new Present<>("2"))), isPresent("1"));
+        assertThat(new NextPresent<>(new Seq<Optional<String>>(new Present<>("1"), new Present<>("2"))), isPresent("1"));
     }
 
 
     @Test
     public void testUsedIterator()
     {
-        Iterator<Optional<String>> it1 = new ArrayIterator<>(new Present<>("1"), ABSENT);
+        Iterator<Optional<String>> it1 = new Seq<>(new Present<>("1"), ABSENT);
         it1.next();
         assertThat(new NextPresent<>(it1), AbsentMatcher.<String>isAbsent());
 
-        Iterator<Optional<String>> it2 = new ArrayIterator<Optional<String>>(new Present<>("1"), new Present<>("2"));
+        Iterator<Optional<String>> it2 = new Seq<Optional<String>>(new Present<>("1"), new Present<>("2"));
         it2.next();
         assertThat(new NextPresent<>(it2), isPresent("2"));
 
-        Iterator<Optional<String>> it3 = new ArrayIterator<Optional<String>>(new Present<>("1"), new Present<>("2"));
+        Iterator<Optional<String>> it3 = new Seq<Optional<String>>(new Present<>("1"), new Present<>("2"));
         it3.next();
         it3.next();
         assertThat(new NextPresent<>(it3), AbsentMatcher.<String>isAbsent());

--- a/optional/src/test/java/org/dmfs/optional/iterable/PresentValuesTest.java
+++ b/optional/src/test/java/org/dmfs/optional/iterable/PresentValuesTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.optional.iterable;
 
-import org.dmfs.iterables.ArrayIterable;
+import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;
 import org.dmfs.optional.Present;
@@ -42,7 +42,7 @@ public final class PresentValuesTest
     @Test
     public void test()
     {
-        Iterable<Optional<String>> optionals = new ArrayIterable<>(
+        Iterable<Optional<String>> optionals = new Seq<>(
                 new Present<>("1"),
                 ABSENT,
                 ABSENT,

--- a/optional/src/test/java/org/dmfs/optional/iterator/PresentValuesTest.java
+++ b/optional/src/test/java/org/dmfs/optional/iterator/PresentValuesTest.java
@@ -17,9 +17,9 @@
 
 package org.dmfs.optional.iterator;
 
-import org.dmfs.iterators.ArrayIterator;
 import org.dmfs.iterators.EmptyIterator;
 import org.dmfs.iterators.SingletonIterator;
+import org.dmfs.iterators.elementary.Seq;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;
 import org.dmfs.optional.Present;
@@ -77,7 +77,7 @@ public final class PresentValuesTest
     @Test
     public void test_various()
     {
-        Iterator<Optional<String>> iterator = new ArrayIterator<>(
+        Iterator<Optional<String>> iterator = new Seq<>(
                 new Present<>("1"),
                 ABSENT,
                 ABSENT,


### PR DESCRIPTION
This also deprecates `ArrayIterable` and `ArrayIterator` in favour of the new `Seq` classes and replaces their occurrences in this library.