### PR TITLE
Add CharSequenceMatcher. Implements #85

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceCharAtMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceCharAtMatcher.java
@@ -31,7 +31,7 @@ import java.util.Locale;
  */
 public final class CharSequenceCharAtMatcher extends TypeSafeDiagnosingMatcher<CharSequence>
 {
-    private final String mExpectedValue;
+    private final CharSequence mExpectedValue;
 
 
     /**
@@ -42,13 +42,13 @@ public final class CharSequenceCharAtMatcher extends TypeSafeDiagnosingMatcher<C
      *
      * @return A {@link CharSequenceCharAtMatcher}.
      */
-    public static CharSequenceCharAtMatcher hasChars(String expectedValues)
+    public static CharSequenceCharAtMatcher hasChars(CharSequence expectedValues)
     {
         return new CharSequenceCharAtMatcher(expectedValues);
     }
 
 
-    public CharSequenceCharAtMatcher(String expectedValue)
+    public CharSequenceCharAtMatcher(CharSequence expectedValue)
     {
         mExpectedValue = expectedValue;
     }
@@ -86,6 +86,6 @@ public final class CharSequenceCharAtMatcher extends TypeSafeDiagnosingMatcher<C
     @Override
     public void describeTo(Description description)
     {
-        description.appendText("chars match \"").appendText(mExpectedValue).appendText("\"");
+        description.appendText("chars match \"").appendText(mExpectedValue.toString()).appendText("\"");
     }
 }

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceCharAtMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceCharAtMatcher.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.Locale;
+
+
+/**
+ * A {@link Matcher} which checks that {@code charAt} of a {@link CharSequence} returns expected values.
+ *
+ * @author Marten Gajda
+ */
+public final class CharSequenceCharAtMatcher extends TypeSafeDiagnosingMatcher<CharSequence>
+{
+    private final String mExpectedValue;
+
+
+    /**
+     * Returns a {@link Matcher} to check the {@code charAt} method of a {@link CharSequence} by comparing it to a String.
+     *
+     * @param expectedValues
+     *         A {@link String} which contains the expected characters.
+     *
+     * @return A {@link CharSequenceCharAtMatcher}.
+     */
+    public static CharSequenceCharAtMatcher hasChars(String expectedValues)
+    {
+        return new CharSequenceCharAtMatcher(expectedValues);
+    }
+
+
+    public CharSequenceCharAtMatcher(String expectedValue)
+    {
+        mExpectedValue = expectedValue;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(CharSequence item, Description mismatchDescription)
+    {
+        for (int i = -mExpectedValue.length() - 1; i < mExpectedValue.length() * 2 + 1; ++i)
+        {
+            if (i < 0 || i >= mExpectedValue.length())
+            {
+                try
+                {
+                    item.charAt(i);
+                    mismatchDescription.appendText(String.format(Locale.ENGLISH, "Did not throw when accessing index %d", i));
+                    return false;
+                }
+                catch (ArrayIndexOutOfBoundsException | StringIndexOutOfBoundsException e)
+                {
+                    // pass
+                }
+            }
+            else if (item.charAt(i) != mExpectedValue.charAt(i))
+            {
+                mismatchDescription.appendText(String.format(Locale.ENGLISH, "char at %d was '%c'", i, item.charAt(i)));
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("chars match \"").appendText(mExpectedValue).appendText("\"");
+    }
+}

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceLengthMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceLengthMatcher.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.Locale;
+
+
+/**
+ * Matches the expected length of a {@link CharSequence}.
+ *
+ * @author Marten Gajda
+ */
+public final class CharSequenceLengthMatcher extends TypeSafeDiagnosingMatcher<CharSequence>
+{
+    private final int mExpectedValue;
+
+
+    /**
+     * Checks that the lenght of a {@link CharSequence} is correct.
+     *
+     * @param expectedLength
+     *         The expected lenght of the {@link CharSequence}
+     *
+     * @return A {@link CharSequenceLengthMatcher}.
+     */
+    public static CharSequenceLengthMatcher hasLength(int expectedLength)
+    {
+        return new CharSequenceLengthMatcher(expectedLength);
+    }
+
+
+    public CharSequenceLengthMatcher(int expectedValue)
+    {
+        mExpectedValue = expectedValue;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(CharSequence item, Description mismatchDescription)
+    {
+        if (item.length() != mExpectedValue)
+        {
+            mismatchDescription.appendText(String.format(Locale.ENGLISH, "had length %d", item.length()));
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText(String.format(Locale.ENGLISH, "has length %d", mExpectedValue));
+    }
+}

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcher.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.AllOf;
+
+import static org.dmfs.jems.hamcrest.matchers.CharSequenceCharAtMatcher.hasChars;
+import static org.dmfs.jems.hamcrest.matchers.CharSequenceLengthMatcher.hasLength;
+import static org.dmfs.jems.hamcrest.matchers.CharSequenceSubSequenceMatcher.hasSubSequences;
+import static org.hamcrest.Matchers.hasToString;
+
+
+/**
+ * @author Marten Gajda
+ */
+public final class CharSequenceMatcher
+{
+
+    private CharSequenceMatcher()
+    {
+    }
+
+
+    /**
+     * Tests the contract of a {@link CharSequence} against the given String value.
+     *
+     * @param expected
+     *         A {@link String} which represents the expected characters.
+     *
+     * @return A {@link Matcher} which tests {@link CharSequence}s.
+     */
+    public static Matcher<CharSequence> validCharSequence(String expected)
+    {
+        return new AllOf<>(
+                new Seq<Matcher<? super CharSequence>>(
+                        hasToString(expected),
+                        hasLength(expected.length()),
+                        hasChars(expected),
+                        hasSubSequences(expected, 3)));
+    }
+
+}

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcher.java
@@ -42,15 +42,15 @@ public final class CharSequenceMatcher
      * Tests the contract of a {@link CharSequence} against the given String value.
      *
      * @param expected
-     *         A {@link String} which represents the expected characters.
+     *         A {@link CharSequence} which represents the expected characters.
      *
      * @return A {@link Matcher} which tests {@link CharSequence}s.
      */
-    public static Matcher<CharSequence> validCharSequence(String expected)
+    public static Matcher<CharSequence> validCharSequence(CharSequence expected)
     {
         return new AllOf<>(
                 new Seq<Matcher<? super CharSequence>>(
-                        hasToString(expected),
+                        hasToString(expected.toString()),
                         hasLength(expected.length()),
                         hasChars(expected),
                         hasSubSequences(expected, 3)));

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceSubSequenceMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceSubSequenceMatcher.java
@@ -37,7 +37,7 @@ import static org.hamcrest.Matchers.hasToString;
  */
 public final class CharSequenceSubSequenceMatcher extends TypeSafeDiagnosingMatcher<CharSequence>
 {
-    private final String mExpectedValue;
+    private final CharSequence mExpectedValue;
     private final int mSubSequenceTestDepth;
 
 
@@ -51,13 +51,13 @@ public final class CharSequenceSubSequenceMatcher extends TypeSafeDiagnosingMatc
      *
      * @return A {@link CharSequenceSubSequenceMatcher}
      */
-    public static CharSequenceSubSequenceMatcher hasSubSequences(String expectedValue, int subSequenceTestDepth)
+    public static CharSequenceSubSequenceMatcher hasSubSequences(CharSequence expectedValue, int subSequenceTestDepth)
     {
         return new CharSequenceSubSequenceMatcher(expectedValue, subSequenceTestDepth);
     }
 
 
-    public CharSequenceSubSequenceMatcher(String expectedValue, int subSequenceTestDepth)
+    public CharSequenceSubSequenceMatcher(CharSequence expectedValue, int subSequenceTestDepth)
     {
         mExpectedValue = expectedValue;
         mSubSequenceTestDepth = subSequenceTestDepth;
@@ -96,7 +96,7 @@ public final class CharSequenceSubSequenceMatcher extends TypeSafeDiagnosingMatc
                 else
                 {
                     // test valid indexes
-                    String expected = mExpectedValue.substring(i, j);
+                    String expected = mExpectedValue.subSequence(i, j).toString();
                     Matcher<CharSequence> subSequenceMatcher = new AllOf<>(
                             new Seq<Matcher<? super CharSequence>>(
                                     hasToString(expected),
@@ -119,6 +119,6 @@ public final class CharSequenceSubSequenceMatcher extends TypeSafeDiagnosingMatc
     @Override
     public void describeTo(Description description)
     {
-        description.appendText("sub-sequences match \"").appendText(mExpectedValue).appendText("\"");
+        description.appendText("sub-sequences match \"").appendText(mExpectedValue.toString()).appendText("\"");
     }
 }

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceSubSequenceMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceSubSequenceMatcher.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.hamcrest.core.AllOf;
+
+import java.util.Locale;
+
+import static org.dmfs.jems.hamcrest.matchers.CharSequenceCharAtMatcher.hasChars;
+import static org.dmfs.jems.hamcrest.matchers.CharSequenceLengthMatcher.hasLength;
+import static org.hamcrest.Matchers.hasToString;
+
+
+/**
+ * A {@link Matcher} to check that all sub-sequences of a {@link CharSequence} are valid {@link CharSequence}s themselves.
+ *
+ * @author Marten Gajda
+ */
+public final class CharSequenceSubSequenceMatcher extends TypeSafeDiagnosingMatcher<CharSequence>
+{
+    private final String mExpectedValue;
+    private final int mSubSequenceTestDepth;
+
+
+    /**
+     * Test that sub-sequences of a {@link CharSequence} are valid {@link CharSequence}s as well.
+     *
+     * @param expectedValue
+     *         The value to compare.
+     * @param subSequenceTestDepth
+     *         The recursion depth.
+     *
+     * @return A {@link CharSequenceSubSequenceMatcher}
+     */
+    public static CharSequenceSubSequenceMatcher hasSubSequences(String expectedValue, int subSequenceTestDepth)
+    {
+        return new CharSequenceSubSequenceMatcher(expectedValue, subSequenceTestDepth);
+    }
+
+
+    public CharSequenceSubSequenceMatcher(String expectedValue, int subSequenceTestDepth)
+    {
+        mExpectedValue = expectedValue;
+        mSubSequenceTestDepth = subSequenceTestDepth;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(CharSequence item, Description mismatchDescription)
+    {
+        if (mSubSequenceTestDepth == 0)
+        {
+            // don't test any deeper to avoid infinite loops
+            return true;
+        }
+        int max = mExpectedValue.length();
+
+        // note, this loop can be quite intense for longer charSequences, consider reducing the tested range
+        for (int i = -max - 1; i <= max * 2 + 1; ++i)
+        {
+            for (int j = -max - 1; j <= max * 2 + 1; ++j)
+            {
+                if (i < 0 || j > max || j < i)
+                {
+                    // test illegal indexes
+                    try
+                    {
+                        item.subSequence(i, j);
+                        mismatchDescription.appendText(String.format(Locale.ENGLISH, "subSequence(%d, %d) did not throw", i, j));
+                        return false;
+                    }
+                    catch (ArrayIndexOutOfBoundsException | StringIndexOutOfBoundsException e)
+                    {
+                        // pass
+                    }
+                }
+                else
+                {
+                    // test valid indexes
+                    String expected = mExpectedValue.substring(i, j);
+                    Matcher<CharSequence> subSequenceMatcher = new AllOf<>(
+                            new Seq<Matcher<? super CharSequence>>(
+                                    hasToString(expected),
+                                    hasLength(expected.length()),
+                                    hasChars(expected),
+                                    hasSubSequences(expected, mSubSequenceTestDepth - 1)));
+                    if (!subSequenceMatcher.matches(item.subSequence(i, j)))
+                    {
+                        mismatchDescription.appendText(String.format(Locale.ENGLISH, "subSequence(%d, %d) ", i, j));
+                        subSequenceMatcher.describeMismatch(item.subSequence(i, j), mismatchDescription);
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("sub-sequences match \"").appendText(mExpectedValue).appendText("\"");
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceCharAtMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceCharAtMatcherTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.CharSequenceCharAtMatcher.hasChars;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class CharSequenceCharAtMatcherTest
+{
+    @Test
+    public void testMatchesSafely() throws Exception
+    {
+        Description describeTo = new StringDescription();
+        assertTrue(hasChars("").matchesSafely("", describeTo));
+        assertTrue(hasChars("1").matchesSafely("1", describeTo));
+        assertTrue(hasChars("123").matchesSafely("123", describeTo));
+    }
+
+
+    @Test
+    public void testMatchesInvalid1() throws Exception
+    {
+        Description describeTo = new StringDescription();
+
+        // test charAt does not equal
+        assertFalse(hasChars("123").matchesSafely(new CharSequenceMatcherTest.TestSequence("123")
+        {
+            @Override
+            public char charAt(int i)
+            {
+                return i != 1 ? super.charAt(i) : 'x';
+            }
+        }, describeTo));
+
+        assertThat(describeTo.toString(), is("char at 1 was 'x'"));
+    }
+
+
+    @Test
+    public void testMatchesInvalid2() throws Exception
+    {
+        Description describeTo = new StringDescription();
+        // test charAt does not throw
+        assertFalse(hasChars("123").matchesSafely(new CharSequenceMatcherTest.TestSequence("123")
+        {
+            @Override
+            public char charAt(int i)
+            {
+                return i < 3 ? super.charAt(i) : '1';
+            }
+        }, describeTo));
+
+        assertThat(describeTo.toString(), is("Did not throw when accessing index 3"));
+    }
+
+
+    @Test
+    public void testMatchesInvalid3() throws Exception
+    {
+        Description describeTo = new StringDescription();
+        // test charAt does not throw
+        assertFalse(hasChars("").matchesSafely(new CharSequenceMatcherTest.TestSequence("")
+        {
+            @Override
+            public char charAt(int i)
+            {
+                return i >= 0 ? '1' : super.charAt(i);
+            }
+        }, describeTo));
+
+        assertThat(describeTo.toString(), is("Did not throw when accessing index 0"));
+    }
+
+
+    @Test
+    public void testMatchesInvalid4() throws Exception
+    {
+        Description describeTo = new StringDescription();
+        // test charAt does not throw
+        assertFalse(hasChars("123").matchesSafely(new CharSequenceMatcherTest.TestSequence("123")
+        {
+            @Override
+            public char charAt(int i)
+            {
+                return i >= 0 ? super.charAt(i) : '1';
+            }
+        }, describeTo));
+
+        assertThat(describeTo.toString(), is("Did not throw when accessing index -4"));
+    }
+
+
+    @Test
+    public void testDescribeTo()
+    {
+        Description describeTo = new StringDescription();
+        hasChars("123").describeTo(describeTo);
+        assertThat(describeTo.toString(), is("chars match \"123\""));
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceLengthMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceLengthMatcherTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.CharSequenceLengthMatcher.hasLength;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * @author marten
+ */
+public class CharSequenceLengthMatcherTest
+{
+    @Test
+    public void testMatchesSafely() throws Exception
+    {
+        Description describeTo = new StringDescription();
+        assertTrue(hasLength(0).matchesSafely("", describeTo));
+        assertTrue(hasLength(1).matchesSafely("1", describeTo));
+        assertTrue(hasLength(3).matchesSafely("123", describeTo));
+    }
+
+
+    @Test
+    public void testMismatches() throws Exception
+    {
+        Description describeTo = new StringDescription();
+
+        assertFalse(hasLength(2).matchesSafely("1234", describeTo));
+
+        assertThat(describeTo.toString(), is("had length 4"));
+    }
+
+
+    @Test
+    public void testDescribeTo() throws Exception
+    {
+        Description describeTo = new StringDescription();
+        hasLength(3).describeTo(describeTo);
+        assertThat(describeTo.toString(), is("has length 3"));
+    }
+
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcherTest.java
@@ -17,8 +17,6 @@
 
 package org.dmfs.jems.hamcrest.matchers;
 
-import org.hamcrest.Description;
-import org.hamcrest.StringDescription;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.CharSequenceMatcher.validCharSequence;
@@ -43,7 +41,7 @@ public class CharSequenceMatcherTest
     @Test
     public void testCharSequenceChatAtMismatch() throws Exception
     {
-        // test charAt does not throw
+        // test charAt with wrong result
         assertFalse(validCharSequence("123").matches(new TestSequence("123")
         {
             @Override
@@ -52,15 +50,13 @@ public class CharSequenceMatcherTest
                 return i != 1 ? super.charAt(i) : 'x';
             }
         }));
-
-        Description description = new StringDescription();
     }
 
 
     @Test
     public void testCharSequenceChatAtNoException1() throws Exception
     {
-        // test charAt does not throw
+        // test charAt which doesn't throw at invalid index
         assertFalse(validCharSequence("123").matches(new TestSequence("123")
         {
             @Override
@@ -75,7 +71,7 @@ public class CharSequenceMatcherTest
     @Test
     public void testCharSequenceChatAtNoException2() throws Exception
     {
-        // test charAt does not throw
+        // test charAt which doesn't throw at invalid index
         assertFalse(validCharSequence("123").matches(new TestSequence("123")
         {
             @Override
@@ -90,6 +86,7 @@ public class CharSequenceMatcherTest
     @Test
     public void testCharSequenceWrongToString() throws Exception
     {
+        // test wrong result of toString()
         assertFalse(validCharSequence("123").matches(new TestSequence("123")
         {
             @Override
@@ -119,6 +116,7 @@ public class CharSequenceMatcherTest
     @Test
     public void testCharSequenceWrongSubSequence() throws Exception
     {
+        // test subSequence with wrong result
         assertFalse(validCharSequence("123").matches(new TestSequence("123")
         {
             @Override
@@ -133,6 +131,7 @@ public class CharSequenceMatcherTest
     @Test
     public void testCharSequenceNotThrowing1() throws Exception
     {
+        // test subSequence which doesn't throw at invalid index
         assertFalse(validCharSequence("123").matches(new TestSequence("123")
         {
             @Override
@@ -147,6 +146,7 @@ public class CharSequenceMatcherTest
     @Test
     public void testCharSequenceNotThrowing2() throws Exception
     {
+        // test subSequence which doesn't throw at invalid index
         assertFalse(validCharSequence("123").matches(new TestSequence("123")
         {
             @Override

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcherTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.CharSequenceMatcher.validCharSequence;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class CharSequenceMatcherTest
+{
+    @Test
+    public void testCharSequenceMatches() throws Exception
+    {
+        assertTrue(validCharSequence("").matches(""));
+        assertTrue(validCharSequence("1").matches("1"));
+        assertTrue(validCharSequence("1234").matches("1234"));
+    }
+
+
+    @Test
+    public void testCharSequenceChatAtMismatch() throws Exception
+    {
+        // test charAt does not throw
+        assertFalse(validCharSequence("123").matches(new TestSequence("123")
+        {
+            @Override
+            public char charAt(int i)
+            {
+                return i != 1 ? super.charAt(i) : 'x';
+            }
+        }));
+
+        Description description = new StringDescription();
+    }
+
+
+    @Test
+    public void testCharSequenceChatAtNoException1() throws Exception
+    {
+        // test charAt does not throw
+        assertFalse(validCharSequence("123").matches(new TestSequence("123")
+        {
+            @Override
+            public char charAt(int i)
+            {
+                return i < 3 ? super.charAt(i) : '1';
+            }
+        }));
+    }
+
+
+    @Test
+    public void testCharSequenceChatAtNoException2() throws Exception
+    {
+        // test charAt does not throw
+        assertFalse(validCharSequence("123").matches(new TestSequence("123")
+        {
+            @Override
+            public char charAt(int i)
+            {
+                return i >= 0 ? super.charAt(i) : '1';
+            }
+        }));
+    }
+
+
+    @Test
+    public void testCharSequenceWrongToString() throws Exception
+    {
+        assertFalse(validCharSequence("123").matches(new TestSequence("123")
+        {
+            @Override
+            public String toString()
+            {
+                return "1234";
+            }
+        }));
+    }
+
+
+    @Test
+    public void testCharSequenceWrongLength() throws Exception
+    {
+        // wrong length
+        assertFalse(validCharSequence("123").matches(new TestSequence("123")
+        {
+            @Override
+            public int length()
+            {
+                return 2;
+            }
+        }));
+    }
+
+
+    @Test
+    public void testCharSequenceWrongSubSequence() throws Exception
+    {
+        assertFalse(validCharSequence("123").matches(new TestSequence("123")
+        {
+            @Override
+            public CharSequence subSequence(int i, int i1)
+            {
+                return "122".subSequence(i, i1);
+            }
+        }));
+    }
+
+
+    @Test
+    public void testCharSequenceNotThrowing1() throws Exception
+    {
+        assertFalse(validCharSequence("123").matches(new TestSequence("123")
+        {
+            @Override
+            public CharSequence subSequence(int i, int i1)
+            {
+                return i < 0 ? "1" : super.subSequence(i, i1);
+            }
+        }));
+    }
+
+
+    @Test
+    public void testCharSequenceNotThrowing2() throws Exception
+    {
+        assertFalse(validCharSequence("123").matches(new TestSequence("123")
+        {
+            @Override
+            public CharSequence subSequence(int i, int i1)
+            {
+                return i1 > 3 ? "1" : super.subSequence(i, i1);
+            }
+        }));
+    }
+
+
+    public abstract static class TestSequence implements CharSequence
+    {
+        private final CharSequence mDelegate;
+
+
+        protected TestSequence(CharSequence delegate)
+        {
+            mDelegate = delegate;
+        }
+
+
+        @Override
+        public int length()
+        {
+            return mDelegate.length();
+        }
+
+
+        @Override
+        public char charAt(int i)
+        {
+            return mDelegate.charAt(i);
+        }
+
+
+        @Override
+        public CharSequence subSequence(int i, int i1)
+        {
+            return mDelegate.subSequence(i, i1);
+        }
+
+
+        @Override
+        public String toString()
+        {
+            return mDelegate.toString();
+        }
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcherTest.java
@@ -39,7 +39,7 @@ public class CharSequenceMatcherTest
 
 
     @Test
-    public void testCharSequenceChatAtMismatch() throws Exception
+    public void testCharSequenceCharAtMismatch() throws Exception
     {
         // test charAt with wrong result
         assertFalse(validCharSequence("123").matches(new TestSequence("123")
@@ -54,7 +54,7 @@ public class CharSequenceMatcherTest
 
 
     @Test
-    public void testCharSequenceChatAtNoException1() throws Exception
+    public void testCharSequenceCharAtNoException1() throws Exception
     {
         // test charAt which doesn't throw at invalid index
         assertFalse(validCharSequence("123").matches(new TestSequence("123")
@@ -69,7 +69,7 @@ public class CharSequenceMatcherTest
 
 
     @Test
-    public void testCharSequenceChatAtNoException2() throws Exception
+    public void testCharSequenceCharAtNoException2() throws Exception
     {
         // test charAt which doesn't throw at invalid index
         assertFalse(validCharSequence("123").matches(new TestSequence("123")

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceSubSequenceMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/CharSequenceSubSequenceMatcherTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.CharSequenceSubSequenceMatcher.hasSubSequences;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * @author marten
+ */
+public class CharSequenceSubSequenceMatcherTest
+{
+    @Test
+    public void testMatchesSafely() throws Exception
+    {
+        // to be ignored
+        Description describeTo = new StringDescription();
+        assertTrue(hasSubSequences("", 10).matchesSafely("", describeTo));
+        assertTrue(hasSubSequences("1", 10).matchesSafely("1", describeTo));
+        assertTrue(hasSubSequences("123", 10).matchesSafely("123", describeTo));
+    }
+
+
+    @Test
+    public void testMismatches1() throws Exception
+    {
+        Description describeTo = new StringDescription();
+
+        assertFalse(hasSubSequences("123", 10).matchesSafely(new CharSequenceMatcherTest.TestSequence("123")
+        {
+
+            public CharSequence subSequence(int i, int i1)
+            {
+                return i1 > 3 ? "1234" : super.subSequence(i, i1);
+            }
+
+        }, describeTo));
+
+        assertThat(describeTo.toString(), is("subSequence(-4, 4) did not throw"));
+    }
+
+
+    @Test
+    public void testMismatches2() throws Exception
+    {
+        Description describeTo = new StringDescription();
+
+        assertFalse(hasSubSequences("123", 10).matchesSafely(new CharSequenceMatcherTest.TestSequence("123")
+        {
+
+            public CharSequence subSequence(int i, int i1)
+            {
+                return i >= 0 && i1 <= 3 && i <= i1 ? "12" : super.subSequence(i, i1);
+            }
+
+        }, describeTo));
+
+        assertThat(describeTo.toString(), is("subSequence(0, 0) with toString() \"\" toString() was \"12\""));
+    }
+
+
+    @Test
+    public void testMismatches3() throws Exception
+    {
+        Description describeTo = new StringDescription();
+
+        assertFalse(hasSubSequences("123", 10).matchesSafely(new CharSequenceMatcherTest.TestSequence("123")
+        {
+
+            public CharSequence subSequence(int i, int i1)
+            {
+                return i >= 0 && i1 <= 3 && i1 < i ? "12" : super.subSequence(i, i1);
+            }
+
+        }, describeTo));
+
+        assertThat(describeTo.toString(), is("subSequence(0, -4) did not throw"));
+    }
+
+
+    @Test
+    public void testMismatches4() throws Exception
+    {
+        Description describeTo = new StringDescription();
+
+        assertFalse(hasSubSequences("123", 10).matchesSafely(new CharSequenceMatcherTest.TestSequence("123")
+        {
+
+            public CharSequence subSequence(int i, int i1)
+            {
+                return new CharSequenceMatcherTest.TestSequence("123".subSequence(i, i1))
+                {
+                    @Override
+                    public char charAt(int i)
+                    {
+                        return i == 1 ? 'x' : super.charAt(i);
+                    }
+                };
+            }
+
+        }, describeTo));
+
+        assertThat(describeTo.toString(), is("subSequence(0, 1) chars match \"1\" Did not throw when accessing index 1"));
+    }
+
+
+    @Test
+    public void testMismatches5() throws Exception
+    {
+        Description describeTo = new StringDescription();
+
+        assertFalse(hasSubSequences("123", 10).matchesSafely(new CharSequenceMatcherTest.TestSequence("123")
+        {
+
+            public CharSequence subSequence(final int i, final int i1)
+            {
+                return new CharSequenceMatcherTest.TestSequence("123".subSequence(i, i1))
+                {
+                    @Override
+                    public char charAt(int index)
+                    {
+                        return index == 0 && i == 0 && i1 == 1 ? 'x' : super.charAt(index);
+                    }
+                };
+            }
+
+        }, describeTo));
+
+        assertThat(describeTo.toString(), is("subSequence(0, 1) chars match \"1\" char at 0 was 'x'"));
+    }
+
+
+    @Test
+    public void testDescribeTo() throws Exception
+    {
+        Description describeTo = new StringDescription();
+        hasSubSequences("123", 10).describeTo(describeTo);
+        assertThat(describeTo.toString(), is("sub-sequences match \"123\""));
+    }
+
+}

--- a/src/test/java/org/dmfs/jems/charsequence/elementary/HexTest.java
+++ b/src/test/java/org/dmfs/jems/charsequence/elementary/HexTest.java
@@ -19,6 +19,7 @@ package org.dmfs.jems.charsequence.elementary;
 
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.CharSequenceMatcher.validCharSequence;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -29,132 +30,33 @@ import static org.junit.Assert.assertThat;
 public class HexTest
 {
     @Test
-    public void testLength() throws Exception
+    public void test() throws Exception
     {
-        assertThat(new Hex(new byte[0]).length(), is(0));
-        assertThat(new Hex(new byte[] { 1 }).length(), is(2));
-        assertThat(new Hex(new byte[] { 1, 2, 3 }).length(), is(6));
+        assertThat(new Hex(new byte[0]), is(validCharSequence("")));
+        assertThat(new Hex(new byte[] { 1 }), is(validCharSequence("01")));
+        assertThat(new Hex(new byte[] { (byte) 0xff }), is(validCharSequence("ff")));
+        assertThat(new Hex(new byte[] { 1, 2, 3 }), is(validCharSequence("010203")));
+        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }),
+                is(validCharSequence("0123456789abcdef")));
 
-        assertThat(new Hex(new byte[] { 1 }, 0, 1).length(), is(2));
-        assertThat(new Hex(new byte[] { 1, 2, 3 }, 1, 1).length(), is(0));
-        assertThat(new Hex(new byte[] { 1, 2, 3 }, 1, 2).length(), is(2));
-    }
+        assertThat(new Hex(new byte[0], 0, 0), is(validCharSequence("")));
 
+        assertThat(new Hex(new byte[] { 1 }, 0, 1), is(validCharSequence("01")));
+        assertThat(new Hex(new byte[] { 1 }, 0, 0), is(validCharSequence("")));
+        assertThat(new Hex(new byte[] { 1 }, 1, 1), is(validCharSequence("")));
 
-    @Test
-    public void testCharAt() throws Exception
-    {
-        assertThat(new Hex(new byte[] { 1 }).charAt(0), is('0'));
-        assertThat(new Hex(new byte[] { 1 }).charAt(1), is('1'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(0), is('0'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(1), is('1'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(2), is('2'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(3), is('3'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(4), is('4'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(5), is('5'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(6), is('6'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(7), is('7'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(8), is('8'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(9), is('9'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(10), is('a'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(11), is('b'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(12), is('c'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(13), is('d'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(14), is('e'));
-        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }).charAt(15), is('f'));
+        assertThat(new Hex(new byte[] { (byte) 0xff }, 0, 1), is(validCharSequence("ff")));
+        assertThat(new Hex(new byte[] { (byte) 0xff }, 0, 0), is(validCharSequence("")));
+        assertThat(new Hex(new byte[] { (byte) 0xff }, 1, 1), is(validCharSequence("")));
 
-        assertThat(new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }, 1, 2).charAt(0), is('1'));
-        assertThat(new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }, 1, 2).charAt(1), is('2'));
-    }
+        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }, 0, 8),
+                is(validCharSequence("0123456789abcdef")));
+        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }, 0, 1),
+                is(validCharSequence("01")));
+        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }, 7, 8),
+                is(validCharSequence("ef")));
+        assertThat(new Hex(new byte[] { 0x01, 0x23, 0x45, 0x67, (byte) 0x89, (byte) 0xab, (byte) 0xcd, (byte) 0xef }, 3, 7),
+                is(validCharSequence("6789abcd")));
 
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    public void testCharAtFail1() throws Exception
-    {
-        new Hex(new byte[] {}).charAt(0);
-    }
-
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    public void testCharAtFail2() throws Exception
-    {
-        new Hex(new byte[] { 0x01 }).charAt(-1);
-    }
-
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    public void testCharAtFail3() throws Exception
-    {
-        new Hex(new byte[] { 0x01 }).charAt(2);
-    }
-
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    public void testCharAtFail4() throws Exception
-    {
-        new Hex(new byte[] { 0x01, 0x02, 0x03 }, 1, 2).charAt(2);
-    }
-
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    public void testCharAtFail5() throws Exception
-    {
-        new Hex(new byte[] { 0x01, 0x02, 0x03 }, 1, 2).charAt(-1);
-    }
-
-
-    @Test
-    public void testSubSequence() throws Exception
-    {
-        assertThat(new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }).subSequence(1, 5).toString(), is("f12a"));
-        assertThat(new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }).subSequence(1, 5).charAt(1), is('1'));
-        assertThat(new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }).subSequence(1, 5).length(), is(4));
-        assertThat(new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }).subSequence(1, 5).subSequence(1, 3).toString(), is("12"));
-
-        assertThat(new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }, 1, 2).subSequence(1, 2).toString(), is("2"));
-    }
-
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    public void testSubSequenceFail1() throws Exception
-    {
-        new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }).subSequence(1, 7);
-    }
-
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    public void testSubSequenceFail2() throws Exception
-    {
-        new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }).subSequence(-1, 5);
-    }
-
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    public void testSubSequenceFail3() throws Exception
-    {
-        new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }).subSequence(4, 2);
-    }
-
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    public void testSubSequenceFail4() throws Exception
-    {
-        new Hex(new byte[] {}).subSequence(1, 1);
-    }
-
-
-    @Test(expected = ArrayIndexOutOfBoundsException.class)
-    public void testSubSequenceFail5() throws Exception
-    {
-        new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }, 1, 2).subSequence(1, 3);
-    }
-
-
-    @Test
-    public void testToString() throws Exception
-    {
-        assertThat(new Hex(new byte[] {}).toString(), is(""));
-        assertThat(new Hex(new byte[] { 1 }).toString(), is("01"));
-        assertThat(new Hex(new byte[] { (byte) 0xff, 0x12, (byte) 0xa9 }).toString(), is("ff12a9"));
     }
 }


### PR DESCRIPTION
This adds a method `validCharSequence(String)` which returns a `Matcher<CharSequence>` which tests `CharSequences` for compliance with the CharSequence contract.
It does not only check for expected method results, but also for Exceptions being thrown for invalid arguments.

This also replaces the unit test for `Hex` with the new `Matcher`.