### PR TITLE
Add IntSequenceGenerator. Implements #89

### DIFF
--- a/src/main/java/org/dmfs/jems/iterable/decorators/Numbered.java
+++ b/src/main/java/org/dmfs/jems/iterable/decorators/Numbered.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import org.dmfs.iterables.composite.Zipped;
+import org.dmfs.iterables.decorators.DelegatingIterable;
+import org.dmfs.jems.function.elementary.PairingFunction;
+import org.dmfs.jems.iterable.generators.IntSequenceGenerator;
+import org.dmfs.jems.pair.Pair;
+
+
+/**
+ * An {@link Iterable} decorator which pairs every value of another iterator with it's sequential ordinal number.
+ * <p>
+ * Example:
+ * <pre><code>
+ *     Iterable&lt;String&gt; strings = new Seq&lt;&gt;("a", "b", "c");
+ *     for (Pair&lt;Integer, String&gt; item:new Numbered&lt;&gt;(strings))
+ *     {
+ *        System.out.println(String.format("%d: %s", item.left(), item.right());
+ *     }
+ * </code></pre>
+ * results in
+ * <pre>
+ * 0: a
+ * 1: b
+ * 2: c
+ * </pre>
+ *
+ * @author Marten Gajda
+ */
+public final class Numbered<T> extends DelegatingIterable<Pair<Integer, T>>
+{
+    public Numbered(Iterable<T> delegate)
+    {
+        this(delegate, 0, 1);
+    }
+
+
+    public Numbered(Iterable<T> delegate, int start)
+    {
+        this(delegate, start, 1);
+    }
+
+
+    public Numbered(Iterable<T> delegate, int start, int step)
+    {
+        super(new Zipped<>(new IntSequenceGenerator(start, step), delegate, new PairingFunction<Integer, T>()));
+    }
+}

--- a/src/main/java/org/dmfs/jems/iterable/generators/IntSequenceGenerator.java
+++ b/src/main/java/org/dmfs/jems/iterable/generators/IntSequenceGenerator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.generators;
+
+import java.util.Iterator;
+
+
+/**
+ * An {@link Iterable} of sequential integers.
+ * <p>
+ * Note, this {@link Iterable} stops iterating when the iterated value would leave the integer range.
+ *
+ * @author Marten Gajda
+ */
+public final class IntSequenceGenerator implements Iterable<Integer>
+{
+    private final int mStart;
+    private final int mStep;
+
+
+    /**
+     * Creates a sequence of {@link Integer} starting at {@code 0} with a step size of {@code 1}.
+     */
+    public IntSequenceGenerator()
+    {
+        this(0, 1);
+    }
+
+
+    /**
+     * Creates a sequence of {@link Integer} starting at the give value with a step size of {@code 1}.
+     */
+    public IntSequenceGenerator(int start)
+    {
+        this(start, 1);
+    }
+
+
+    /**
+     * Creates a sequence of {@link Integer} starting at the give value with the given step size.
+     */
+    public IntSequenceGenerator(int start, int step)
+    {
+        mStart = start;
+        mStep = step;
+    }
+
+
+    @Override
+    public Iterator<Integer> iterator()
+    {
+        return new org.dmfs.jems.iterator.generators.IntSequenceGenerator(mStart, mStep);
+    }
+}

--- a/src/main/java/org/dmfs/jems/iterator/generators/IntSequenceGenerator.java
+++ b/src/main/java/org/dmfs/jems/iterator/generators/IntSequenceGenerator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterator.generators;
+
+import org.dmfs.iterators.AbstractBaseIterator;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+
+/**
+ * An {@link Iterator} which iterates {@link Integer}s from a given start in given steps.
+ * <p>
+ * Note, this {@link Iterator} stops iterating when the iterated value would leave the integer range.
+ *
+ * @author Marten Gajda
+ */
+public final class IntSequenceGenerator extends AbstractBaseIterator<Integer>
+{
+    private long mNext;
+    private final int mStep;
+
+
+    public IntSequenceGenerator()
+    {
+        this(0, 1);
+    }
+
+
+    public IntSequenceGenerator(int next)
+    {
+        this(next, 1);
+    }
+
+
+    public IntSequenceGenerator(int next, int step)
+    {
+        mNext = next;
+        mStep = step;
+    }
+
+
+    @Override
+    public boolean hasNext()
+    {
+        return mNext >= Integer.MIN_VALUE && mNext <= Integer.MAX_VALUE;
+    }
+
+
+    @Override
+    public Integer next()
+    {
+        if (!hasNext())
+        {
+            throw new NoSuchElementException("Generator overflow. Next value is not an Integer anymore.");
+        }
+        int result = (int) mNext;
+        mNext += mStep;
+        return result;
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterable/decorators/NumberedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/NumberedTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.dmfs.jems.hamcrest.matchers.PairMatcher.pair;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class NumberedTest
+{
+    @Test
+    public void testEmpty()
+    {
+        assertThat(new Numbered<>(EmptyIterable.instance()), emptyIterable());
+        assertThat(new Numbered<>(EmptyIterable.instance(), 1), emptyIterable());
+        assertThat(new Numbered<>(EmptyIterable.instance(), 1, 1), emptyIterable());
+    }
+
+
+    @Test
+    public void testBase0Step1()
+    {
+        assertThat(new Numbered<>(new Seq<>("a")), iteratesTo(pair(is(0), is("a"))));
+        assertThat(new Numbered<>(new Seq<>("a", "b", "c")), iteratesTo(pair(is(0), is("a")), pair(is(1), is("b")), pair(is(2), is("c"))));
+
+        assertThat(new Numbered<>(new Seq<>("a"), 0), iteratesTo(pair(is(0), is("a"))));
+        assertThat(new Numbered<>(new Seq<>("a", "b", "c"), 0), iteratesTo(pair(is(0), is("a")), pair(is(1), is("b")), pair(is(2), is("c"))));
+
+        assertThat(new Numbered<>(new Seq<>("a"), 0, 1), iteratesTo(pair(is(0), is("a"))));
+        assertThat(new Numbered<>(new Seq<>("a", "b", "c"), 0, 1), iteratesTo(pair(is(0), is("a")), pair(is(1), is("b")), pair(is(2), is("c"))));
+    }
+
+
+    @Test
+    public void testBase1Step1()
+    {
+        assertThat(new Numbered<>(new Seq<>("a"), 1), iteratesTo(pair(is(1), is("a"))));
+        assertThat(new Numbered<>(new Seq<>("a", "b", "c"), 1), iteratesTo(pair(is(1), is("a")), pair(is(2), is("b")), pair(is(3), is("c"))));
+
+        assertThat(new Numbered<>(new Seq<>("a"), 1, 1), iteratesTo(pair(is(1), is("a"))));
+        assertThat(new Numbered<>(new Seq<>("a", "b", "c"), 1, 1), iteratesTo(pair(is(1), is("a")), pair(is(2), is("b")), pair(is(3), is("c"))));
+    }
+
+
+    @Test
+    public void testBase0Step10()
+    {
+        assertThat(new Numbered<>(new Seq<>("a"), 0, 10), iteratesTo(pair(is(0), is("a"))));
+        assertThat(new Numbered<>(new Seq<>("a", "b", "c"), 0, 10), iteratesTo(pair(is(0), is("a")), pair(is(10), is("b")), pair(is(20), is("c"))));
+    }
+
+
+    @Test
+    public void testBase10Step10()
+    {
+        assertThat(new Numbered<>(new Seq<>("a"), 10, 10), iteratesTo(pair(is(10), is("a"))));
+        assertThat(new Numbered<>(new Seq<>("a", "b", "c"), 10, 10), iteratesTo(pair(is(10), is("a")), pair(is(20), is("b")), pair(is(30), is("c"))));
+    }
+
+}

--- a/src/test/java/org/dmfs/jems/iterable/generators/IntSequenceGeneratorTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/generators/IntSequenceGeneratorTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.generators;
+
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class IntSequenceGeneratorTest
+{
+    @Test
+    public void testIterator() throws Exception
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator().iterator();
+        for (int i = 0; i < 1_000_000; i++)
+        {
+            // multiple calls to hasNext should not advance the counter
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.next(), is(i));
+        }
+        assertThat(sequence.hasNext(), is(true));
+    }
+
+
+    @Test
+    public void testIteratorBase10() throws Exception
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator(10).iterator();
+        for (int i = 0; i < 1_000_000; i++)
+        {
+            // multiple calls to hasNext should not advance the counter
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.next(), is(i + 10));
+        }
+        assertThat(sequence.hasNext(), is(true));
+    }
+
+
+    @Test
+    public void testIteratorBase10Step10() throws Exception
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator(10, 10).iterator();
+        for (int i = 0; i < 1_000_000; i++)
+        {
+            // multiple calls to hasNext should not advance the counter
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.next(), is(i * 10 + 10));
+        }
+        assertThat(sequence.hasNext(), is(true));
+    }
+
+
+    @Test
+    public void testIteratorBase10StepBackwards() throws Exception
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator(10, -1).iterator();
+        for (int i = 0; i < 1_000_000; i++)
+        {
+            // multiple calls to hasNext should not advance the counter
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.next(), is(-i + 10));
+        }
+        assertThat(sequence.hasNext(), is(true));
+    }
+
+
+    @Test
+    public void testOverflow()
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator(Integer.MAX_VALUE - 1).iterator();
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+
+        assertThat(sequence.next(), is(Integer.MAX_VALUE - 1));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+
+        assertThat(sequence.next(), is(Integer.MAX_VALUE));
+
+        assertThat(sequence.hasNext(), is(false));
+        assertThat(sequence.hasNext(), is(false));
+        assertThat(sequence.hasNext(), is(false));
+
+        try
+        {
+            sequence.next();
+            fail("Did not throw");
+        }
+        catch (NoSuchElementException e)
+        {
+            // pass
+        }
+    }
+
+
+    @Test
+    public void testUnderflow()
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator(Integer.MIN_VALUE + 1, -1).iterator();
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+
+        assertThat(sequence.next(), is(Integer.MIN_VALUE + 1));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+
+        assertThat(sequence.next(), is(Integer.MIN_VALUE));
+
+        assertThat(sequence.hasNext(), is(false));
+        assertThat(sequence.hasNext(), is(false));
+        assertThat(sequence.hasNext(), is(false));
+
+        try
+        {
+            sequence.next();
+            fail("Did not throw");
+        }
+        catch (NoSuchElementException e)
+        {
+            // pass
+        }
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterator/generators/IntSequenceGeneratorTest.java
+++ b/src/test/java/org/dmfs/jems/iterator/generators/IntSequenceGeneratorTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterator.generators;
+
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+
+/**
+ * @author marten
+ */
+public class IntSequenceGeneratorTest
+{
+    @Test
+    public void testIterator() throws Exception
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator();
+        for (int i = 0; i < 1_000_000; i++)
+        {
+            // multiple calls to hasNext should not advance the counter
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.next(), is(i));
+        }
+        assertThat(sequence.hasNext(), is(true));
+    }
+
+
+    @Test
+    public void testIteratorBase10() throws Exception
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator(10);
+        for (int i = 0; i < 1_000_000; i++)
+        {
+            // multiple calls to hasNext should not advance the counter
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.next(), is(i + 10));
+        }
+        assertThat(sequence.hasNext(), is(true));
+    }
+
+
+    @Test
+    public void testIteratorBase10Step10() throws Exception
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator(10, 10);
+        for (int i = 0; i < 1_000_000; i++)
+        {
+            // multiple calls to hasNext should not advance the counter
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.next(), is(i * 10 + 10));
+        }
+        assertThat(sequence.hasNext(), is(true));
+    }
+
+
+    @Test
+    public void testIteratorBase10StepBackwards() throws Exception
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator(10, -1);
+        for (int i = 0; i < 1_000_000; i++)
+        {
+            // multiple calls to hasNext should not advance the counter
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.hasNext(), is(true));
+            assertThat(sequence.next(), is(-i + 10));
+        }
+        assertThat(sequence.hasNext(), is(true));
+    }
+
+
+    @Test
+    public void testOverflow()
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator(Integer.MAX_VALUE - 1);
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+
+        assertThat(sequence.next(), is(Integer.MAX_VALUE - 1));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+
+        assertThat(sequence.next(), is(Integer.MAX_VALUE));
+
+        assertThat(sequence.hasNext(), is(false));
+        assertThat(sequence.hasNext(), is(false));
+        assertThat(sequence.hasNext(), is(false));
+
+        try
+        {
+            sequence.next();
+            fail("Did not throw");
+        }
+        catch (NoSuchElementException e)
+        {
+            // pass
+        }
+    }
+
+
+    @Test
+    public void testUnderflow()
+    {
+        Iterator<Integer> sequence = new IntSequenceGenerator(Integer.MIN_VALUE + 1, -1);
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+
+        assertThat(sequence.next(), is(Integer.MIN_VALUE + 1));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+        assertThat(sequence.hasNext(), is(true));
+
+        assertThat(sequence.next(), is(Integer.MIN_VALUE));
+
+        assertThat(sequence.hasNext(), is(false));
+        assertThat(sequence.hasNext(), is(false));
+        assertThat(sequence.hasNext(), is(false));
+
+        try
+        {
+            sequence.next();
+            fail("Did not throw");
+        }
+        catch (NoSuchElementException e)
+        {
+            // pass
+        }
+    }
+
+}


### PR DESCRIPTION
This adds Iterable and Iterator generators for integer sequences.
Also adds a use case: Numbered decorator for Iterables, which zips the delegate with an IntSequenceGenerator and returns Pairs of Integers and the original elements.