### PR TITLE
Grouped CharSequence decorator. Implements #81

### DIFF
--- a/src/main/java/org/dmfs/jems/charsequence/decorators/Grouped.java
+++ b/src/main/java/org/dmfs/jems/charsequence/decorators/Grouped.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.charsequence.decorators;
+
+import org.dmfs.jems.single.Single;
+import org.dmfs.jems.single.elementary.Frozen;
+
+
+/**
+ * A {@link CharSequence} decorator which divides the delegate into groups of a specific size and inserts a separator char between them.
+ * <p>
+ * Example:
+ * <pre><code>
+ * assertThat(new Grouped(2, ':', "abcdef"), is(validCharSequence("ab:cd:ef")));
+ * </code></pre>
+ *
+ * @author Marten Gajda
+ */
+public final class Grouped implements CharSequence
+{
+    private final CharSequence mDelegate;
+    private final int mGroupSize;
+    private final char mSeparator;
+    private final Single<String> mToString;
+
+
+    public Grouped(final int groupSize, final char separator, final CharSequence delegate)
+    {
+        mDelegate = delegate;
+        mGroupSize = groupSize;
+        mSeparator = separator;
+        mToString = new Frozen<>(new Single<String>()
+        {
+            @Override
+            public String value()
+            {
+                int len = delegate.length();
+                StringBuilder stringBuilder = new StringBuilder(length());
+                int i = 0;
+                while (i < len)
+                {
+                    stringBuilder.append(delegate.charAt(i++));
+                    if ((i < len) && i % groupSize == 0)
+                    {
+                        stringBuilder.append(separator);
+                    }
+                }
+                return stringBuilder.toString();
+            }
+        });
+    }
+
+
+    @Override
+    public int length()
+    {
+        int delegateLength = mDelegate.length();
+        return delegateLength + Math.max(0, (delegateLength + mGroupSize - 1) / mGroupSize - 1);
+    }
+
+
+    @Override
+    public char charAt(int i)
+    {
+        if (i < 0 || i >= length())
+        {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        int group = i / (mGroupSize + 1);
+        return (i + 1) % (mGroupSize + 1) == 0 ? mSeparator : mDelegate.charAt(i - group);
+    }
+
+
+    @Override
+    public CharSequence subSequence(int i, int i1)
+    {
+        // creating a subsequence of a Grouped CharSequence would be too much of a hassle with a decorator.
+        // So at this point we just create a string and return the subsequence of it.
+        return toString().subSequence(i, i1);
+    }
+
+
+    @Override
+    public String toString()
+    {
+        return mToString.value();
+    }
+}

--- a/src/test/java/org/dmfs/jems/charsequence/decorators/GroupedTest.java
+++ b/src/test/java/org/dmfs/jems/charsequence/decorators/GroupedTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.charsequence.decorators;
+
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.CharSequenceMatcher.validCharSequence;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class GroupedTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new Grouped(1, ':', ""), is(validCharSequence("")));
+        assertThat(new Grouped(1, ':', "a"), is(validCharSequence("a")));
+        assertThat(new Grouped(1, ':', "ab"), is(validCharSequence("a:b")));
+        assertThat(new Grouped(1, ':', "abc"), is(validCharSequence("a:b:c")));
+        assertThat(new Grouped(1, ':', "abcd"), is(validCharSequence("a:b:c:d")));
+        assertThat(new Grouped(1, ':', "abcde"), is(validCharSequence("a:b:c:d:e")));
+        assertThat(new Grouped(1, ':', "abcdef"), is(validCharSequence("a:b:c:d:e:f")));
+        assertThat(new Grouped(1, ':', "abcdefg"), is(validCharSequence("a:b:c:d:e:f:g")));
+        assertThat(new Grouped(2, ':', ""), is(validCharSequence("")));
+        assertThat(new Grouped(2, ':', "a"), is(validCharSequence("a")));
+        assertThat(new Grouped(2, ':', "ab"), is(validCharSequence("ab")));
+        assertThat(new Grouped(2, ':', "abc"), is(validCharSequence("ab:c")));
+        assertThat(new Grouped(2, ':', "abcd"), is(validCharSequence("ab:cd")));
+        assertThat(new Grouped(2, ':', "abcde"), is(validCharSequence("ab:cd:e")));
+        assertThat(new Grouped(2, ':', "abcdef"), is(validCharSequence("ab:cd:ef")));
+        assertThat(new Grouped(2, ':', "abcdefg"), is(validCharSequence("ab:cd:ef:g")));
+        assertThat(new Grouped(3, ':', ""), is(validCharSequence("")));
+        assertThat(new Grouped(3, ':', "a"), is(validCharSequence("a")));
+        assertThat(new Grouped(3, ':', "ab"), is(validCharSequence("ab")));
+        assertThat(new Grouped(3, ':', "abc"), is(validCharSequence("abc")));
+        assertThat(new Grouped(3, ':', "abcd"), is(validCharSequence("abc:d")));
+        assertThat(new Grouped(3, ':', "abcde"), is(validCharSequence("abc:de")));
+        assertThat(new Grouped(3, ':', "abcdef"), is(validCharSequence("abc:def")));
+        assertThat(new Grouped(3, ':', "abcdefg"), is(validCharSequence("abc:def:g")));
+    }
+}


### PR DESCRIPTION
Adds a Grouped decorator which groups the characters of the delegate and inserts a separator char between the groups like so:

```java
assertThat(new Grouped(2, ':', "abcdef"), is(validCharSequence("ab:cd:ef")));
```