### PR TITLE
Add `Joined` `Iterable`, Implements #108

### DIFF
--- a/src/main/java/org/dmfs/jems/iterable/composite/Expanded.java
+++ b/src/main/java/org/dmfs/jems/iterable/composite/Expanded.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.composite;
+
+import org.dmfs.iterables.decorators.DelegatingIterable;
+import org.dmfs.jems.function.Function;
+import org.dmfs.jems.iterable.decorators.Mapped;
+
+
+/**
+ * A decorator for {@link Iterable} which expands each element into an {@link Iterable} (using the given function) and joins the results.
+ * <p>
+ * This resembles what other frameworks call "flatmap".
+ *
+ * @author Marten Gajda
+ */
+public final class Expanded<T> extends DelegatingIterable<T>
+{
+    public <V> Expanded(Function<V, Iterable<T>> function, Iterable<V> delegate)
+    {
+        super(new Joined<>(new Mapped<>(function, delegate)));
+    }
+}

--- a/src/main/java/org/dmfs/jems/iterable/composite/Joined.java
+++ b/src/main/java/org/dmfs/jems/iterable/composite/Joined.java
@@ -15,37 +15,42 @@
  * limitations under the License.
  */
 
-package org.dmfs.iterables.decorators;
+package org.dmfs.jems.iterable.composite;
 
-import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.iterable.composite.Joined;
+import org.dmfs.iterables.decorators.Mapped;
+import org.dmfs.jems.function.Function;
 
 import java.util.Iterator;
 
 
 /**
- * An {@link Iterable} which iterates the elements of other {@link Iterable}s.
+ * An {@link Iterable} which joins other {@link Iterable}s by iterating the values of them one after another.
  *
  * @param <T>
  *         The type of the iterated elements.
  *
  * @author Marten Gajda
- * @deprecated in favour of {@link Joined}
  */
-@Deprecated
-public final class Flattened<T> implements Iterable<T>
+public final class Joined<T> implements Iterable<T>
 {
     private final Iterable<Iterable<T>> mIterables;
 
 
-    @SafeVarargs
-    public Flattened(Iterable<T>... iterables)
+    public <V> Joined(final Function<V, Iterable<T>> function, Iterable<V> iterables)
     {
-        this(new Seq<>(iterables));
+        this(new Mapped<>(iterables, new org.dmfs.iterators.Function<V, Iterable<T>>()
+        {
+
+            @Override
+            public Iterable<T> apply(V argument)
+            {
+                return function.value(argument);
+            }
+        }));
     }
 
 
-    public Flattened(Iterable<Iterable<T>> iterables)
+    public Joined(Iterable<Iterable<T>> iterables)
     {
         mIterables = iterables;
     }

--- a/src/main/java/org/dmfs/jems/iterable/composite/Joined.java
+++ b/src/main/java/org/dmfs/jems/iterable/composite/Joined.java
@@ -17,14 +17,23 @@
 
 package org.dmfs.jems.iterable.composite;
 
-import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.jems.function.Function;
+import org.dmfs.iterables.elementary.Seq;
 
 import java.util.Iterator;
 
 
 /**
  * An {@link Iterable} which joins other {@link Iterable}s by iterating the values of them one after another.
+ * <p>
+ * Note: other frameworks call this operation, "flatten". While this is technically appropriate, it often doesn't really express the intent very well. For
+ * instance, if you want to iterate the elements of two lists one after another, this code is probably easier to grasp:
+ * <pre><code>
+ * Iterable&lt;SomeType&gt; result = new Joined&lt;&gt;(list1, list2);
+ * </code></pre>
+ * than this one
+ * <pre><code>
+ * Iterable&lt;SomeType&gt; result = new Flattened&lt;&gt;(list1, list2);
+ * </code></pre>
  *
  * @param <T>
  *         The type of the iterated elements.
@@ -36,17 +45,10 @@ public final class Joined<T> implements Iterable<T>
     private final Iterable<Iterable<T>> mIterables;
 
 
-    public <V> Joined(final Function<V, Iterable<T>> function, Iterable<V> iterables)
+    @SafeVarargs
+    public Joined(Iterable<T>... iterables)
     {
-        this(new Mapped<>(iterables, new org.dmfs.iterators.Function<V, Iterable<T>>()
-        {
-
-            @Override
-            public Iterable<T> apply(V argument)
-            {
-                return function.value(argument);
-            }
-        }));
+        this(new Seq<>(iterables));
     }
 
 

--- a/src/test/java/org/dmfs/jems/iterable/composite/ExpandedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/composite/ExpandedTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.composite;
+
+import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.function.Function;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class ExpandedTest
+{
+
+    @Test
+    public void test() throws Exception
+    {
+        Function<Object, Iterable<Object>> dummyFunction = dummy(Function.class);
+        assertThat(new Expanded<>(dummyFunction, EmptyIterable.instance()), Matchers.emptyIterable());
+        assertThat(new Expanded<>(
+                        new Function<String, Iterable<String>>()
+                        {
+                            @Override
+                            public Iterable<String> value(String s)
+                            {
+                                return new Seq<>(s + "1", s + "2", s + "3");
+                            }
+                        },
+                        new Seq<>("a", "b", "c")
+                ),
+                contains("a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3"));
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterable/composite/JoinedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/composite/JoinedTest.java
@@ -20,7 +20,6 @@ package org.dmfs.jems.iterable.composite;
 import org.dmfs.iterables.EmptyIterable;
 import org.dmfs.iterables.SingletonIterable;
 import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.function.Function;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;
@@ -98,20 +97,29 @@ public class JoinedTest
 
 
     @Test
-    public void testMappingCtor() throws Exception
+    public void testVarArgCtor() throws Exception
     {
         assertThat(new Joined<>(
-                        new Function<String, Iterable<String>>()
-                        {
-                            @Override
-                            public Iterable<String> value(String s)
-                            {
-                                return new Seq<>(s + "1", s + "2", s + "3");
-                            }
-                        },
-                        new Seq<>("a", "b", "c")
+                        new Seq<>("1", "2", "3"),
+                        new Seq<>("a", "b", "c"),
+                        new Seq<>("z", "zz", "zzz")
                 ),
-                contains("a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3"));
-    }
+                contains("1", "2", "3", "a", "b", "c", "z", "zz", "zzz"));
 
+        assertThat(new Joined<>(
+                        EmptyIterable.<String>instance(),
+                        new Seq<>("1", "2", "3"),
+                        new Seq<>("a", "b", "c"),
+                        new Seq<>("z", "zz", "zzz")
+                ),
+                contains("1", "2", "3", "a", "b", "c", "z", "zz", "zzz"));
+
+        assertThat(new Joined<>(
+                        new Seq<>("1", "2", "3"),
+                        new Seq<>("a", "b", "c"),
+                        new Seq<>("z", "zz", "zzz"),
+                        EmptyIterable.<String>instance()
+                ),
+                contains("1", "2", "3", "a", "b", "c", "z", "zz", "zzz"));
+    }
 }

--- a/src/test/java/org/dmfs/jems/iterable/composite/JoinedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/composite/JoinedTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.composite;
+
+import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.SingletonIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.function.Function;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.emptyIterableOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class JoinedTest
+{
+    @Test
+    public void testTrivial() throws Exception
+    {
+        assertThat(new Joined<>(EmptyIterable.<Iterable<String>>instance()), emptyIterableOf(String.class));
+        assertThat(new Joined<>(new Seq<Iterable<String>>(EmptyIterable.<String>instance())), emptyIterableOf(String.class));
+    }
+
+
+    @Test
+    public void testSingle() throws Exception
+    {
+        assertThat(new Joined<>(new Seq<Iterable<String>>(new SingletonIterable<>("1"))), contains("1"));
+    }
+
+
+    @Test
+    public void testMultiSingle() throws Exception
+    {
+        assertThat(new Joined<>(new Seq<Iterable<String>>(new SingletonIterable<>("1"), new SingletonIterable<>("2"), new SingletonIterable<>("3"))),
+                contains("1", "2", "3"));
+    }
+
+
+    @Test
+    public void testMulti() throws Exception
+    {
+        assertThat(new Joined<>(new Seq<Iterable<String>>(new Seq<>("1", "2", "3"))), contains("1", "2", "3"));
+        assertThat(new Joined<>(new Seq<>(new Seq<>("1", "2", "3"), EmptyIterable.<String>instance())), contains("1", "2", "3"));
+        assertThat(new Joined<>(new Seq<>(EmptyIterable.<String>instance(), new Seq<>("1", "2", "3"), EmptyIterable.<String>instance())),
+                contains("1", "2", "3"));
+    }
+
+
+    @Test
+    public void testMultiMulti() throws Exception
+    {
+        assertThat(new Joined<>(
+                        new Seq<Iterable<String>>(
+                                new Seq<>("1", "2", "3"),
+                                new Seq<>("a", "b", "c"),
+                                new Seq<>("z", "zz", "zzz")
+                        )),
+                contains("1", "2", "3", "a", "b", "c", "z", "zz", "zzz"));
+
+        assertThat(new Joined<>(
+                        new Seq<>(
+                                EmptyIterable.<String>instance(),
+                                new Seq<>("1", "2", "3"),
+                                new Seq<>("a", "b", "c"),
+                                new Seq<>("z", "zz", "zzz")
+                        )),
+                contains("1", "2", "3", "a", "b", "c", "z", "zz", "zzz"));
+
+        assertThat(new Joined<>(
+                        new Seq<>(
+                                new Seq<>("1", "2", "3"),
+                                new Seq<>("a", "b", "c"),
+                                new Seq<>("z", "zz", "zzz"),
+                                EmptyIterable.<String>instance()
+                        )),
+                contains("1", "2", "3", "a", "b", "c", "z", "zz", "zzz"));
+    }
+
+
+    @Test
+    public void testMappingCtor() throws Exception
+    {
+        assertThat(new Joined<>(
+                        new Function<String, Iterable<String>>()
+                        {
+                            @Override
+                            public Iterable<String> value(String s)
+                            {
+                                return new Seq<>(s + "1", s + "2", s + "3");
+                            }
+                        },
+                        new Seq<>("a", "b", "c")
+                ),
+                contains("a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3"));
+    }
+
+}


### PR DESCRIPTION
This deprarecates `Flattened`. Note the new `Joined` class doesn't have a varargs constructor because this can be confusing when joining `Iterable`s of `Iterable`s.