### PR TITLE
Fix AbsentMatcher to work with any kind of Optional class. #115

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,4 +14,4 @@ POM_DESCRIPTION=Java gems, a collection of Java utilities.
 # Common dependencies
 JUNIT=4.12
 HAMCREST=1.3
-MOCKITO=2.10.0
+MOCKITO=2.12.0

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/AbsentMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/AbsentMatcher.java
@@ -53,6 +53,7 @@ public final class AbsentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T
             mismatchDescription.appendText("present");
             return false;
         }
+
         try
         {
             item.value();
@@ -64,21 +65,18 @@ public final class AbsentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T
             // pass
         }
 
-        T fallbackDummy = mFallbackDummySingle.value();
-        T fallbackMethodResult;
         try
         {
-            fallbackMethodResult = item.value(fallbackDummy);
+            T fallbackDummy = mFallbackDummySingle.value();
+            if (item.value(fallbackDummy) != fallbackDummy)
+            {
+                mismatchDescription.appendText("value(default) did not return the default value");
+                return false;
+            }
         }
         catch (ClassCastException e)
         {
             throw new RuntimeException("ClassCastException in AbsentMatcher, need to use #absent(Class<T> c) or #absent(T t) method", e);
-        }
-
-        if (fallbackMethodResult != fallbackDummy)
-        {
-            mismatchDescription.appendText("value(default) did not return the default value");
-            return false;
         }
 
         return true;

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/AbsentMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/AbsentMatcher.java
@@ -17,27 +17,31 @@
 
 package org.dmfs.jems.hamcrest.matchers;
 
+import org.dmfs.jems.mockito.doubles.DummySingle;
+import org.dmfs.jems.single.Single;
+import org.dmfs.jems.single.elementary.ValueSingle;
 import org.dmfs.optional.Optional;
 import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.NoSuchElementException;
 
 
 /**
+ * {@link Matcher} or {@link Optional} that matches when the tested value is absent.
+ *
  * @author Marten Gajda
+ * @author Gabor Keszthelyi
  */
 public final class AbsentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T>>
 {
-    private static final AbsentMatcher<?> INSTANCE = new AbsentMatcher<>();
-
-    private static final Object DUMMY_DEFAULT = new Object();
+    private final Single<T> mFallbackDummySingle;
 
 
-    public static <T> AbsentMatcher<T> isAbsent()
+    private AbsentMatcher(Single<T> fallbackDummySingle)
     {
-        //noinspection unchecked
-        return (AbsentMatcher<T>) INSTANCE;
+        mFallbackDummySingle = fallbackDummySingle;
     }
 
 
@@ -60,7 +64,18 @@ public final class AbsentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T
             // pass
         }
 
-        if (((Optional) item).value(DUMMY_DEFAULT) != DUMMY_DEFAULT)
+        T fallbackDummy = mFallbackDummySingle.value();
+        T fallbackMethodResult;
+        try
+        {
+            fallbackMethodResult = item.value(fallbackDummy);
+        }
+        catch (ClassCastException e)
+        {
+            throw new RuntimeException("ClassCastException in AbsentMatcher, need to use #absent(Class<T> c) or #absent(T t) method", e);
+        }
+
+        if (fallbackMethodResult != fallbackDummy)
         {
             mismatchDescription.appendText("value(default) did not return the default value");
             return false;
@@ -74,5 +89,48 @@ public final class AbsentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T
     public void describeTo(Description description)
     {
         description.appendText("absent");
+    }
+
+
+    /**
+     * Creates a matcher that matches when the tested value is absent,
+     * <p>
+     * works with any kind of `Optional` class.
+     *
+     * @param fallbackDummy
+     *         used for testing the {@link Optional#value(Object)} method
+     * @param <T>
+     *         the type parameter of the tested {@link Optional}
+     */
+    public static <T> AbsentMatcher<T> isAbsent(T fallbackDummy)
+    {
+        return new AbsentMatcher<>(new ValueSingle<T>(fallbackDummy));
+    }
+
+
+    /**
+     * Creates a matcher that matches when the tested value is absent,
+     * <p>
+     * works with `Optional` classes whose parameter type is a general type, or an interface, or a non-final class (so Mockito can create a dummy instance)
+     * (throws with clear message otherwise).
+     *
+     * @param <T>
+     *         the type parameter of the tested {@link Optional}
+     */
+    public static <T> AbsentMatcher<T> isAbsent(final Class<T> clazz)
+    {
+        return new AbsentMatcher<>(new DummySingle<T>(clazz, "in AbsentMatcher, need to use #absent() or #absent(T t) method"));
+    }
+
+
+    /**
+     * Creates a matcher that matches when the tested value is absent,
+     * <p>
+     * works with `Optional` classes that have generic type parameter (throws with clear message otherwise).
+     */
+    public static <T> AbsentMatcher<T> isAbsent()
+    {
+        //noinspection unchecked
+        return (AbsentMatcher<T>) new AbsentMatcher<>(new ValueSingle<>(new Object()));
     }
 }

--- a/jems-testing/src/main/java/org/dmfs/jems/mockito/doubles/DummySingle.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/mockito/doubles/DummySingle.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.mockito.doubles;
+
+import org.dmfs.jems.single.Single;
+import org.mockito.exceptions.base.MockitoException;
+
+
+/**
+ * {@link Single} for a dummy test double instance of <code>T</code>.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class DummySingle<T> implements Single<T>
+{
+    private final Class<T> mClass;
+    private final String mFailExtraMessage;
+
+
+    public DummySingle(Class<T> clazz, String failExtraMessage)
+    {
+        mClass = clazz;
+        mFailExtraMessage = failExtraMessage;
+    }
+
+
+    public DummySingle(Class<T> clazz)
+    {
+        this(clazz, "");
+    }
+
+
+    @Override
+    public T value()
+    {
+        try
+        {
+            return TestDoubles.dummy(mClass);
+        }
+        catch (MockitoException e)
+        {
+            throw new RuntimeException(String.format(
+                    "Can't create dummy for class %s %s", mClass.getSimpleName(), mFailExtraMessage), e);
+        }
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/AbsentMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/AbsentMatcherTest.java
@@ -17,27 +17,263 @@
 
 package org.dmfs.jems.hamcrest.matchers;
 
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Present;
-import org.hamcrest.CoreMatchers;
+import org.dmfs.optional.Optional;
 import org.hamcrest.Description;
 import org.junit.Test;
 
-import static org.junit.Assert.assertThat;
+import java.util.Date;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 /**
  * Test for {@link AbsentMatcher}.
  *
- * @author Marten Gajda
+ * @author Gabor Keszthelyi
  */
-public class AbsentMatcherTest
+public final class AbsentMatcherTest
 {
     @Test
-    public void testMatchesSafely() throws Exception
+    public void test_absent_noArg()
     {
-        assertThat(new AbsentMatcher<String>().matchesSafely(Absent.<String>absent(), new Description.NullDescription()), CoreMatchers.is(true));
-        assertThat(new AbsentMatcher<String>().matchesSafely(new Present<>("test"), new Description.NullDescription()), CoreMatchers.is(false));
+        assertTrue(AbsentMatcher.isAbsent().matchesSafely(new GenericTypeAbsent<>(), desc()));
+        assertFalse(AbsentMatcher.<String>isAbsent().matchesSafely(new GenericTypePresent<>("3"), desc()));
+
+        assertThrows(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                AbsentMatcher.<Date>isAbsent().matchesSafely(new FixNonFinalTypeAbsent(), desc());
+            }
+        });
+        assertFalse(AbsentMatcher.<Date>isAbsent().matchesSafely(new FixNonFinalTypePresent(), desc()));
+
+        assertThrows(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                AbsentMatcher.<String>isAbsent().matchesSafely(new FixFinalTypeAbsent(), desc());
+            }
+        });
+        assertFalse(AbsentMatcher.<String>isAbsent().matchesSafely(new FixFinalTypePresent(), desc()));
+    }
+
+
+    @Test
+    public void test_absent_classArg()
+    {
+        assertTrue(AbsentMatcher.isAbsent(CharSequence.class).matchesSafely(new GenericTypeAbsent<CharSequence>(), desc()));
+        assertFalse(AbsentMatcher.isAbsent(CharSequence.class).matchesSafely(new GenericTypePresent<CharSequence>("3"), desc()));
+
+        assertTrue(AbsentMatcher.isAbsent(Date.class).matchesSafely(new FixNonFinalTypeAbsent(), desc()));
+        assertFalse(AbsentMatcher.isAbsent(Date.class).matchesSafely(new FixNonFinalTypePresent(), desc()));
+
+        assertThrows(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                AbsentMatcher.isAbsent(String.class).matchesSafely(new FixFinalTypeAbsent(), desc());
+            }
+        });
+        assertFalse(AbsentMatcher.isAbsent(String.class).matchesSafely(new FixFinalTypePresent(), desc()));
+    }
+
+
+    @Test
+    public void test_absent_dummyArg()
+    {
+        assertTrue(AbsentMatcher.isAbsent("3").matchesSafely(new GenericTypeAbsent<String>(), desc()));
+        assertFalse(AbsentMatcher.isAbsent("3").matchesSafely(new GenericTypePresent<>("5"), desc()));
+
+        assertTrue(AbsentMatcher.isAbsent(new Date()).matchesSafely(new FixNonFinalTypeAbsent(), desc()));
+        assertFalse(AbsentMatcher.isAbsent(new Date()).matchesSafely(new FixNonFinalTypePresent(), desc()));
+
+        assertTrue(AbsentMatcher.isAbsent("6").matchesSafely(new FixFinalTypeAbsent(), desc()));
+        assertFalse(AbsentMatcher.isAbsent("6").matchesSafely(new FixFinalTypePresent(), desc()));
+    }
+
+
+    private void assertThrows(Runnable runnable)
+    {
+        try
+        {
+            runnable.run();
+            fail("Should have thrown exception");
+        }
+        catch (Exception e)
+        {
+            // pass
+        }
+    }
+
+
+    private Description.NullDescription desc()
+    {
+        return new Description.NullDescription();
+    }
+
+
+    private static final class FixFinalTypeAbsent implements Optional<String>
+    {
+
+        @Override
+        public boolean isPresent()
+        {
+            return false;
+        }
+
+
+        @Override
+        public String value(String defaultValue)
+        {
+            return defaultValue;
+        }
+
+
+        @Override
+        public String value() throws NoSuchElementException
+        {
+            throw new NoSuchElementException();
+        }
+    }
+
+
+    private static final class FixFinalTypePresent implements Optional<String>
+    {
+
+        @Override
+        public boolean isPresent()
+        {
+            return true;
+        }
+
+
+        @Override
+        public String value(String defaultValue)
+        {
+            return "789";
+        }
+
+
+        @Override
+        public String value() throws NoSuchElementException
+        {
+            return "789";
+        }
+    }
+
+
+    private static final class FixNonFinalTypeAbsent implements Optional<Date>
+    {
+
+        @Override
+        public boolean isPresent()
+        {
+            return false;
+        }
+
+
+        @Override
+        public Date value(Date defaultValue)
+        {
+            return defaultValue;
+        }
+
+
+        @Override
+        public Date value() throws NoSuchElementException
+        {
+            throw new NoSuchElementException();
+        }
+    }
+
+
+    private static final class FixNonFinalTypePresent implements Optional<Date>
+    {
+
+        @Override
+        public boolean isPresent()
+        {
+            return true;
+        }
+
+
+        @Override
+        public Date value(Date defaultValue)
+        {
+            return new Date(12345);
+        }
+
+
+        @Override
+        public Date value() throws NoSuchElementException
+        {
+            return new Date(12345);
+        }
+    }
+
+
+    private static final class GenericTypeAbsent<T> implements Optional<T>
+    {
+
+        @Override
+        public boolean isPresent()
+        {
+            return false;
+        }
+
+
+        @Override
+        public T value(T defaultValue)
+        {
+            return defaultValue;
+        }
+
+
+        @Override
+        public T value() throws NoSuchElementException
+        {
+            throw new NoSuchElementException();
+        }
+    }
+
+
+    private static final class GenericTypePresent<T> implements Optional<T>
+    {
+        private final T mValue;
+
+
+        private GenericTypePresent(T value)
+        {
+            mValue = value;
+        }
+
+
+        @Override
+        public boolean isPresent()
+        {
+            return true;
+        }
+
+
+        @Override
+        public T value(T defaultValue)
+        {
+            return mValue;
+        }
+
+
+        @Override
+        public T value() throws NoSuchElementException
+        {
+            return mValue;
+        }
     }
 
 }


### PR DESCRIPTION

I see that this casting doesn't always work after all..

I've fixed this while also keeping convenience versions:
```
AbsentMatcher.absent() // works with Optional that has generic type
AbsentMatcher.absent(Class<T> c) // works when T is not final class (creates dummy)
AbsentMatcher.absent(T t) // works with any Optional
```
When a matcher doesn't work with that type it throws a clear exception, so there is no risk of misusing any of the versions.


Just a side note about Kotlin relating to that `Class<T>` version: they have this `reified` generic type solution, which can keep the type without using `Class<T>`.
https://kotlinlang.org/docs/reference/inline-functions.html#reified-type-parameters
It doesn't work in every situation, but here it would, I think. So instead of `absent(Date.class)` it could be `absent<Date>()` or with type inference and omitting the diamond (I think it can be omitted in Kotlin) maybe `absent()`.