### PR TITLE
Add new Generator and Generatable types. Implements #152

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/GeneratableMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/GeneratableMatcher.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.generatable.Generatable;
+import org.dmfs.jems.generator.Generator;
+import org.dmfs.jems.iterable.decorators.Mapped;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+
+/**
+ * A {@link Matcher} to test {@link Generatable}s for the correct start sequence. Note, due do the infinite nature of a {@link Generatable} it is not possible
+ * to test all the results.
+ *
+ * @author Marten Gajda
+ */
+public final class GeneratableMatcher<T> extends TypeSafeDiagnosingMatcher<Generatable<T>>
+{
+    private final Iterable<Matcher<T>> mExpectedStartSequence;
+
+
+    @SafeVarargs
+    public static <T> Matcher<Generatable<T>> startsWith(T... elements)
+    {
+        return new GeneratableMatcher<>(new Mapped<>(CoreMatchers::is, new Seq<>(elements)));
+    }
+
+
+    @SafeVarargs
+    public static <T> Matcher<Generatable<T>> startsWith(Matcher<T>... elements)
+    {
+        return new GeneratableMatcher<>(new Seq<>(elements));
+    }
+
+
+    public static <T> Matcher<Generatable<T>> startsWith(Iterable<Matcher<T>> elements)
+    {
+        return new GeneratableMatcher<>(elements);
+    }
+
+
+    public GeneratableMatcher(Iterable<Matcher<T>> expectedStartSequence)
+    {
+        mExpectedStartSequence = expectedStartSequence;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Generatable<T> item, Description mismatchDescription)
+    {
+        int pos = 0;
+        Generator<T> generator = item.generator();
+        for (Matcher<T> matcher : mExpectedStartSequence)
+        {
+            T next = generator.next();
+            if (!matcher.matches(next))
+            {
+                mismatchDescription.appendText(String.format("element at position %d ", pos));
+                matcher.describeMismatch(next, mismatchDescription);
+                return false;
+            }
+            pos += 1;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("Generatable with start sequence ");
+        boolean first = true;
+        for (Matcher<T> matcher : mExpectedStartSequence)
+        {
+            if (first)
+            {
+                first = false;
+            }
+            else
+            {
+                description.appendText(", ");
+            }
+            matcher.describeTo(description);
+        }
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/GeneratableMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/GeneratableMatcherTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.generatable.Generatable;
+import org.dmfs.jems.generator.Generator;
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.hamcrest.core.IsEqual;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.GeneratableMatcher.startsWith;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.object.HasToString.hasToString;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test {@link GeneratableMatcher}.
+ *
+ * @author Marten Gajda
+ */
+public final class GeneratableMatcherTest
+{
+    @Test
+    public void testStartsWith() throws Exception
+    {
+        assertThat(
+                startsWith(1).matches(new TestGeneratable<>(1)),
+                is(true));
+        assertThat(
+                startsWith(1, 2).matches(new TestGeneratable<>(1, 2)),
+                is(true));
+        assertThat(
+                startsWith(1, 2, 3).matches(new TestGeneratable<>(1, 2, 3)),
+                is(true));
+
+        assertThat(
+                startsWith(10).matches(new TestGeneratable<>(1)),
+                is(false));
+        assertThat(
+                startsWith(10, 2, 3).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+        assertThat(
+                startsWith(1, 20, 3).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+        assertThat(
+                startsWith(1, 2, 30).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+    }
+
+
+    @Test
+    public void testStartsWith1() throws Exception
+    {
+        assertThat(
+                startsWith(new IsEqual<>(1)).matches(new TestGeneratable<>(1)),
+                is(true));
+        assertThat(
+                startsWith(new IsEqual<>(1), new IsEqual<>(2)).matches(new TestGeneratable<>(1, 2)),
+                is(true));
+        assertThat(
+                startsWith(new IsEqual<>(1), new IsEqual<>(2), new IsEqual<>(3)).matches(new TestGeneratable<>(1, 2, 3)),
+                is(true));
+
+        assertThat(
+                startsWith(new IsEqual<>(10)).matches(new TestGeneratable<>(1)),
+                is(false));
+        assertThat(
+                startsWith(new IsEqual<>(10), new IsEqual<>(2), new IsEqual<>(3)).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+        assertThat(
+                startsWith(new IsEqual<>(1), new IsEqual<>(20), new IsEqual<>(3)).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+        assertThat(
+                startsWith(new IsEqual<>(1), new IsEqual<>(2), new IsEqual<>(30)).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+    }
+
+
+    @Test
+    public void testStartsWith2() throws Exception
+    {
+        assertThat(
+                startsWith(new Seq<>(new IsEqual<>(1))).matches(new TestGeneratable<>(1)),
+                is(true));
+        assertThat(
+                startsWith(new Seq<>(new IsEqual<>(1), new IsEqual<>(2))).matches(new TestGeneratable<>(1, 2)),
+                is(true));
+        assertThat(
+                startsWith(new Seq<>(new IsEqual<>(1), new IsEqual<>(2), new IsEqual<>(3))).matches(new TestGeneratable<>(1, 2, 3)),
+                is(true));
+
+        assertThat(
+                startsWith(new Seq<>(new IsEqual<>(10))).matches(new TestGeneratable<>(1)),
+                is(false));
+        assertThat(
+                startsWith(new Seq<>(new IsEqual<>(10), new IsEqual<>(2), new IsEqual<>(3))).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+        assertThat(
+                startsWith(new Seq<>(new IsEqual<>(1), new IsEqual<>(20), new IsEqual<>(3))).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+        assertThat(
+                startsWith(new Seq<>(new IsEqual<>(1), new IsEqual<>(2), new IsEqual<>(30))).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+    }
+
+
+    @Test
+    public void testMatches() throws Exception
+    {
+        assertThat(
+                new GeneratableMatcher<>(new Seq<>(new IsEqual<>(1))).matches(new TestGeneratable<>(1)),
+                is(true));
+        assertThat(
+                new GeneratableMatcher<>(new Seq<>(new IsEqual<>(1), new IsEqual<>(2))).matches(new TestGeneratable<>(1, 2)),
+                is(true));
+        assertThat(
+                new GeneratableMatcher<>(new Seq<>(new IsEqual<>(1), new IsEqual<>(2), new IsEqual<>(3))).matches(new TestGeneratable<>(1, 2, 3)),
+                is(true));
+    }
+
+
+    @Test
+    public void testMismatches() throws Exception
+    {
+        assertThat(
+                new GeneratableMatcher<>(new Seq<>(new IsEqual<>(10))).matches(new TestGeneratable<>(1)),
+                is(false));
+        assertThat(
+                new GeneratableMatcher<>(new Seq<>(new IsEqual<>(10), new IsEqual<>(2), new IsEqual<>(3))).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+        assertThat(
+                new GeneratableMatcher<>(new Seq<>(new IsEqual<>(1), new IsEqual<>(20), new IsEqual<>(3))).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+        assertThat(
+                new GeneratableMatcher<>(new Seq<>(new IsEqual<>(1), new IsEqual<>(2), new IsEqual<>(30))).matches(new TestGeneratable<>(1, 2, 3)),
+                is(false));
+    }
+
+
+    @Test
+    public void testMismatchDescription() throws Exception
+    {
+        Description mismatchMsg = new StringDescription();
+        new GeneratableMatcher<>(new Seq<>(new IsEqual<>(1), new IsEqual<>(20))).describeMismatch(new TestGeneratable<>(1, 2), mismatchMsg);
+        assertThat(mismatchMsg.toString(), is("element at position 1 was <2>"));
+    }
+
+
+    @Test
+    public void testDescribeTo() throws Exception
+    {
+        Description description = new StringDescription();
+        new GeneratableMatcher<>(new Seq<>(new IsEqual<>(1), new IsEqual<>(2))).describeTo(description);
+        assertThat(description, hasToString("Generatable with start sequence <1>, <2>"));
+    }
+
+
+    /**
+     * A Test Generatable which returns a few given values.
+     *
+     * @param <T>
+     */
+    private final static class TestGeneratable<T> implements Generatable<T>
+    {
+        private final T[] mValues;
+
+
+        @SafeVarargs
+        private TestGeneratable(T... values)
+        {
+            mValues = values;
+        }
+
+
+        @Override
+        public Generator<T> generator()
+        {
+            return new Generator<T>()
+            {
+                int i;
+
+
+                @Override
+                public T next()
+                {
+                    return mValues[i++];
+                }
+            };
+        }
+    }
+
+}

--- a/src/main/java/org/dmfs/jems/generatable/Generatable.java
+++ b/src/main/java/org/dmfs/jems/generatable/Generatable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.generatable;
+
+import org.dmfs.jems.generator.Generator;
+import org.dmfs.jems.iterable.adapters.Infinite;
+
+
+/**
+ * A Generatable can return a {@link Generator}. This is the equivalent of {@link Iterable} but for infinite generators. For the sake of single responsibility
+ * and for avoiding the risk of infinite loops this doesn't extent {@link Iterable}. Instead you should use an explicit {@link Iterable} adapter like {@link
+ * Infinite}.
+ * <p>
+ * Instances of this type must be immutable.
+ *
+ * @author Marten Gajda
+ */
+public interface Generatable<T>
+{
+    Generator<T> generator();
+}

--- a/src/main/java/org/dmfs/jems/generatable/elementary/Sequence.java
+++ b/src/main/java/org/dmfs/jems/generatable/elementary/Sequence.java
@@ -29,13 +29,13 @@ import org.dmfs.jems.generator.Generator;
  */
 public final class Sequence<T> implements Generatable<T>
 {
-    private T mNext;
+    private T mFirst;
     private final Function<T, T> mFunction;
 
 
-    public Sequence(T next, Function<T, T> function)
+    public Sequence(T first, Function<T, T> function)
     {
-        mNext = next;
+        mFirst = first;
         mFunction = function;
     }
 
@@ -43,6 +43,6 @@ public final class Sequence<T> implements Generatable<T>
     @Override
     public Generator<T> generator()
     {
-        return new org.dmfs.jems.generator.elementary.Sequence<>(mNext, mFunction);
+        return new org.dmfs.jems.generator.elementary.Sequence<>(mFirst, mFunction);
     }
 }

--- a/src/main/java/org/dmfs/jems/generatable/elementary/Sequence.java
+++ b/src/main/java/org/dmfs/jems/generatable/elementary/Sequence.java
@@ -24,9 +24,6 @@ import org.dmfs.jems.generator.Generator;
 
 /**
  * A sequence {@link Generatable}. It generates a sequence by passing the previous result (or initial value) into a given {@link Function}.
- * <p>
- * Note, this {@link Generator} returned by this Sequence always generates the upcoming value ahead of time, which means it generates one more value than you
- * actually need. For very expensive functions you should consider using a different {@link Generatable}.
  *
  * @author Marten Gajda
  */

--- a/src/main/java/org/dmfs/jems/generatable/elementary/Sequence.java
+++ b/src/main/java/org/dmfs/jems/generatable/elementary/Sequence.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.generatable.elementary;
+
+import org.dmfs.jems.function.Function;
+import org.dmfs.jems.generatable.Generatable;
+import org.dmfs.jems.generator.Generator;
+
+
+/**
+ * A sequence {@link Generatable}. It generates a sequence by passing the previous result (or initial value) into a given {@link Function}.
+ * <p>
+ * Note, this {@link Generator} returned by this Sequence always generates the upcoming value ahead of time, which means it generates one more value than you
+ * actually need. For very expensive functions you should consider using a different {@link Generatable}.
+ *
+ * @author Marten Gajda
+ */
+public final class Sequence<T> implements Generatable<T>
+{
+    private T mNext;
+    private final Function<T, T> mFunction;
+
+
+    public Sequence(T next, Function<T, T> function)
+    {
+        mNext = next;
+        mFunction = function;
+    }
+
+
+    @Override
+    public Generator<T> generator()
+    {
+        return new org.dmfs.jems.generator.elementary.Sequence<>(mNext, mFunction);
+    }
+}

--- a/src/main/java/org/dmfs/jems/generator/Generator.java
+++ b/src/main/java/org/dmfs/jems/generator/Generator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.generator;
+
+import java.util.Iterator;
+
+
+/**
+ * A Generator is able to generate an infinite sequence of values. It's similar to {@link Iterator} with the difference that a generator always has a next
+ * element, hence there is no {@code hasNext()} method.
+ *
+ * @author Marten Gajda
+ */
+public interface Generator<T>
+{
+    /**
+     * Generates and returns another value.
+     *
+     * @return Another generated value.
+     */
+    T next();
+}

--- a/src/main/java/org/dmfs/jems/generator/elementary/Sequence.java
+++ b/src/main/java/org/dmfs/jems/generator/elementary/Sequence.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.generator.elementary;
+
+import org.dmfs.jems.function.Function;
+import org.dmfs.jems.generator.Generator;
+
+
+/**
+ * A sequence {@link Generator}. It generates a sequence by passing the previous result (or initial value) into a given {@link Function}.
+ * <p>
+ * Note, this {@link Generator} always generates the upcoming value ahead of time, which means it generates one more value than you actually need. For very
+ * expensive functions you should consider using a different {@link Generator}.
+ *
+ * @author Marten Gajda
+ */
+public final class Sequence<T> implements Generator<T>
+{
+    private T mNext;
+    private final Function<T, T> mFunction;
+
+
+    public Sequence(T first, Function<T, T> function)
+    {
+        mNext = first;
+        mFunction = function;
+    }
+
+
+    @Override
+    public T next()
+    {
+        // TODO: is it ok to use try-finally like this or should we use the imperative version underneath?
+        // I like this version because it looks very clean and expresses what I want to achieve (if you don't think of it as error handling).
+        try
+        {
+            // return the next result
+            return mNext;
+        }
+        finally
+        {
+            mNext = mFunction.value(mNext);
+        }
+
+        /*
+        // imperative version
+        T next = mNext;
+        mNext = mFunction.value(next);
+        return next;
+        */
+    }
+}

--- a/src/main/java/org/dmfs/jems/generator/elementary/Sequence.java
+++ b/src/main/java/org/dmfs/jems/generator/elementary/Sequence.java
@@ -23,45 +23,29 @@ import org.dmfs.jems.generator.Generator;
 
 /**
  * A sequence {@link Generator}. It generates a sequence by passing the previous result (or initial value) into a given {@link Function}.
- * <p>
- * Note, this {@link Generator} always generates the upcoming value ahead of time, which means it generates one more value than you actually need. For very
- * expensive functions you should consider using a different {@link Generator}.
  *
  * @author Marten Gajda
  */
 public final class Sequence<T> implements Generator<T>
 {
     private T mNext;
-    private final Function<T, T> mFunction;
+    private Function<T, T> mFunction;
 
 
     public Sequence(T first, Function<T, T> function)
     {
         mNext = first;
-        mFunction = function;
+        mFunction = value -> {
+            // the first call returns value as is, afterwards we use the given function
+            mFunction = function;
+            return value;
+        };
     }
 
 
     @Override
     public T next()
     {
-        // TODO: is it ok to use try-finally like this or should we use the imperative version underneath?
-        // I like this version because it looks very clean and expresses what I want to achieve (if you don't think of it as error handling).
-        try
-        {
-            // return the next result
-            return mNext;
-        }
-        finally
-        {
-            mNext = mFunction.value(mNext);
-        }
-
-        /*
-        // imperative version
-        T next = mNext;
-        mNext = mFunction.value(next);
-        return next;
-        */
+        return mNext = mFunction.value(mNext);
     }
 }

--- a/src/main/java/org/dmfs/jems/iterable/adapters/Infinite.java
+++ b/src/main/java/org/dmfs/jems/iterable/adapters/Infinite.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.adapters;
+
+import org.dmfs.jems.generatable.Generatable;
+
+import java.util.Iterator;
+
+
+/**
+ * A {@link Generatable} to {@link Iterable} adapter which continues iterating forever. Be careful when using this in a {@code for} loop and make sure there is
+ * another exit point.
+ *
+ * @author Marten Gajda
+ */
+public final class Infinite<T> implements Iterable<T>
+{
+    private final Generatable<T> mDelegate;
+
+
+    public Infinite(Generatable<T> generatable)
+    {
+        mDelegate = generatable;
+    }
+
+
+    @Override
+    public Iterator<T> iterator()
+    {
+        return new org.dmfs.jems.iterator.adapters.Infinite<>(mDelegate.generator());
+    }
+}

--- a/src/main/java/org/dmfs/jems/iterator/adapters/Infinite.java
+++ b/src/main/java/org/dmfs/jems/iterator/adapters/Infinite.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterator.adapters;
+
+import org.dmfs.jems.generator.Generator;
+
+import java.util.Iterator;
+
+
+/**
+ * An {@link Generator} to {@link Iterator} adapter which iterates infinitely. Be careful when using this with a {@code while} loop and make sure there is
+ * another exit point.
+ *
+ * @author Marten Gajda
+ */
+public final class Infinite<T> implements Iterator<T>
+{
+    private final Generator<T> mDelegate;
+
+
+    public Infinite(Generator<T> generator)
+    {
+        mDelegate = generator;
+    }
+
+
+    @Override
+    public boolean hasNext()
+    {
+        return true;
+    }
+
+
+    @Override
+    public T next()
+    {
+        return mDelegate.next();
+    }
+}

--- a/src/test/java/org/dmfs/jems/generatable/elementary/SequenceTest.java
+++ b/src/test/java/org/dmfs/jems/generatable/elementary/SequenceTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.generatable.elementary;
+
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.GeneratableMatcher.startsWith;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test {@link Sequence}.
+ *
+ * @author Marten Gajda
+ */
+public final class SequenceTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new Sequence<>(1, a -> a + 1), startsWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+        assertThat(new Sequence<>(1, a -> a), startsWith(1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
+        assertThat(new Sequence<>("a", a -> a + "a"), startsWith("a", "aa", "aaa", "aaaa"));
+    }
+}

--- a/src/test/java/org/dmfs/jems/generator/elementary/SequenceTest.java
+++ b/src/test/java/org/dmfs/jems/generator/elementary/SequenceTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.generator.elementary;
+
+import org.dmfs.jems.generator.Generator;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test {@link Sequence}.
+ *
+ * @author Marten Gajda
+ */
+public final class SequenceTest
+{
+    @Test
+    public void test()
+    {
+        Generator<Integer> seq = new Sequence<>(10, i -> i + 10);
+        assertThat(seq.next(), is(10));
+        assertThat(seq.next(), is(20));
+        assertThat(seq.next(), is(30));
+        assertThat(seq.next(), is(40));
+        assertThat(seq.next(), is(50));
+        assertThat(seq.next(), is(60));
+        assertThat(seq.next(), is(70));
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterable/adapters/InfiniteTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/adapters/InfiniteTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.adapters;
+
+import org.dmfs.jems.generatable.Generatable;
+import org.dmfs.jems.generator.Generator;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+
+/**
+ * Test {@link Infinite}.
+ *
+ * @author Marten Gajda
+ */
+public final class InfiniteTest
+{
+    @Test
+    public void test()
+    {
+        // just like with the Infinite Iterable we can not test infinite results, thus the test looks pretty much like org.dmfs.jems.iterator.adapters.InfiniteTest.
+        AtomicReference<Object> reference = new AtomicReference<>(new Object());
+
+        Generatable<Object> dummyGeneratable = mock(Generatable.class);
+        // return a dummy Generator which returns the atomic reference
+        doReturn((Generator) reference::get).when(dummyGeneratable).generator();
+
+        Iterator<Object> infinityIterator = new Infinite<>(dummyGeneratable).iterator();
+
+        for (int i = 0; i < 100; ++i)
+        {
+            assertThat(infinityIterator.hasNext(), is(true));
+            assertThat(infinityIterator.next(), sameInstance(reference.get()));
+
+            // prepare a new result
+            reference.set(new Object());
+        }
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterator/adapters/InfiniteTest.java
+++ b/src/test/java/org/dmfs/jems/iterator/adapters/InfiniteTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterator.adapters;
+
+import org.dmfs.jems.generator.Generator;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test {@link Infinite}.
+ *
+ * @author Marten Gajda
+ */
+public final class InfiniteTest
+{
+
+    @Test
+    public void test()
+    {
+        // note we can not really test "infinite" results. Given 100% test coverage, it should be safe to assume a success if it returns exactly what the generator returns.
+
+        AtomicReference<Object> reference = new AtomicReference<>(new Object());
+
+        // a dummy Generator which returns the atomic reference
+        Generator<Object> dummyGenerator = reference::get;
+
+        Iterator<Object> infinityIterator = new Infinite<>(dummyGenerator);
+
+        for (int i = 0; i < 100; ++i)
+        {
+            assertThat(infinityIterator.hasNext(), is(true));
+            assertThat(infinityIterator.next(), sameInstance(reference.get()));
+
+            // prepare a new result
+            reference.set(new Object());
+        }
+    }
+}


### PR DESCRIPTION
This commit adds two new types to implement something like Iterable/Iterator for generated, infinite series. It also adds a Matcher which tests the start sequence of Generabtables.
In addition it adds initial implementations for Sequences which are based on an initial value and a Function which calculates the next value based on that.

In order to use Generatables like Iterables (which needs to be done carefully because they are infinite) there are initial Generatable-Iterable and Generator-Iterator adapters.