### PR TITLE
Add a simple immutable Set type. Implements #52

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/set/SetContainsMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/set/SetContainsMatcher.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.set;
+
+import org.dmfs.jems.iterable.elementary.Seq;
+import org.dmfs.jems.set.Set;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+
+/**
+ * A {@link Matcher} which checks if a {@link Set} contains the given elements.
+ *
+ * @author Marten Gajda
+ */
+public final class SetContainsMatcher<T> extends TypeSafeDiagnosingMatcher<Set<? super T>>
+{
+
+    private final Iterable<T> mExpectedElements;
+
+
+    public SetContainsMatcher(Iterable<T> expectedElements)
+    {
+        mExpectedElements = expectedElements;
+    }
+
+
+    @SafeVarargs
+    public static <T> Matcher<Set<? super T>> contains(T... expected)
+    {
+        return contains(new Seq<>(expected));
+    }
+
+
+    public static <T> Matcher<Set<? super T>> contains(Iterable<T> expected)
+    {
+        return new SetContainsMatcher<>(expected);
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Set<? super T> item, Description mismatchDescription)
+    {
+        for (T expected : mExpectedElements)
+        {
+            if (!item.contains(expected))
+            {
+                mismatchDescription.appendText(String.format("did not contain %s", expected));
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("contains ");
+        boolean first = true;
+        for (T expected : mExpectedElements)
+        {
+            if (first)
+            {
+                first = false;
+            }
+            else
+            {
+                description.appendText(", ");
+            }
+            description.appendText(expected.toString());
+        }
+    }
+}

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/set/SetLacksMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/set/SetLacksMatcher.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.set;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.set.Set;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+
+/**
+ * A {@link Matcher} which checks if a {@link Set} doesn't contain the given elements.
+ *
+ * @author Marten Gajda
+ */
+public final class SetLacksMatcher<T> extends TypeSafeDiagnosingMatcher<Set<? super T>>
+{
+
+    private final Iterable<T> mUnexpectedElements;
+
+
+    public SetLacksMatcher(Iterable<T> expectedElements)
+    {
+        mUnexpectedElements = expectedElements;
+    }
+
+
+    @SafeVarargs
+    public static <T> Matcher<Set<? super T>> lacks(T... unexpected)
+    {
+        return lacks(new Seq<>(unexpected));
+    }
+
+
+    public static <T> Matcher<Set<? super T>> lacks(Iterable<T> unexpected)
+    {
+        return new SetLacksMatcher<>(unexpected);
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Set<? super T> item, Description mismatchDescription)
+    {
+        for (T unexpected : mUnexpectedElements)
+        {
+            if (item.contains(unexpected))
+            {
+                mismatchDescription.appendText(String.format("did contain %s", unexpected));
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("contains none of ");
+        boolean first = true;
+        for (T unexpected : mUnexpectedElements)
+        {
+            if (first)
+            {
+                first = false;
+            }
+            else
+            {
+                description.appendText(", ");
+            }
+            description.appendText(unexpected.toString());
+        }
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/set/SetContainsMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/set/SetContainsMatcherTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.set;
+
+import org.dmfs.jems.set.Set;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems.hamcrest.matchers.set.SetContainsMatcher.contains;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * @author Marten Gajda
+ */
+public final class SetContainsMatcherTest
+{
+    @Test
+    public void test()
+    {
+        Set<String> mock = failingMock(Set.class);
+        doReturn(false).when(mock).contains(any());
+        doReturn(true).when(mock).contains("a");
+        doReturn(true).when(mock).contains("b");
+        assertThat(contains("a"), matches(mock));
+        assertThat(contains("b"), matches(mock));
+        assertThat(contains("a", "b"), matches(mock));
+        assertThat(contains("a", "c", "d"), mismatches(mock, "did not contain c"));
+        assertThat(contains("c", "d"), mismatches(mock, "did not contain c"));
+        assertThat(contains("a", "b", "c"), describesAs("contains a, b, c"));
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/set/SetLacksMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/set/SetLacksMatcherTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.set;
+
+import org.dmfs.jems.set.Set;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems.hamcrest.matchers.set.SetLacksMatcher.lacks;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * @author Marten Gajda
+ */
+public final class SetLacksMatcherTest
+{
+    @Test
+    public void test()
+    {
+        Set<String> mock = failingMock(Set.class);
+        doReturn(false).when(mock).contains(any());
+        doReturn(true).when(mock).contains("a");
+        doReturn(true).when(mock).contains("b");
+        assertThat(lacks("x"), matches(mock));
+        assertThat(lacks("y"), matches(mock));
+        assertThat(lacks("x", "y"), matches(mock));
+        assertThat(lacks("x", "y", "a"), mismatches(mock, "did contain a"));
+        assertThat(lacks("a", "b"), mismatches(mock, "did contain a"));
+        assertThat(lacks("a", "b", "c"), describesAs("contains none of a, b, c"));
+    }
+}

--- a/src/main/java/org/dmfs/jems/set/Set.java
+++ b/src/main/java/org/dmfs/jems/set/Set.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.set;
+
+/**
+ * A simple immutable set. It can tell whether it contains a specific element.
+ * <p>
+ * A {@link Set} may have an infinite number of elements.
+ *
+ * @author Marten Gajda
+ */
+public interface Set<T>
+{
+    /**
+     * Returns whether this set contains the given element.
+     *
+     * @param element
+     *         The element to test.
+     *
+     * @return {@code true} if the given element is an element of this set, {@code false} otherwise.
+     */
+    boolean contains(T element);
+}

--- a/src/main/java/org/dmfs/jems/set/elementary/Interval.java
+++ b/src/main/java/org/dmfs/jems/set/elementary/Interval.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.set.elementary;
+
+import org.dmfs.jems.set.Set;
+
+
+/**
+ * Represents a <i>closed</i> interval of {@link Comparable} objects.
+ *
+ * @author Marten Gajda
+ */
+public final class Interval<T extends Comparable<T>> implements Set<T>
+{
+    private final T mStart;
+    private final T mEnd;
+
+
+    /**
+     * Creates an {@link Interval}. Note, if {@code start > end} this will degenerate to an empty interval.
+     *
+     * @param start
+     *         The lower bound of the interval.
+     * @param end
+     *         The upper bound of the interval.
+     */
+    public Interval(T start, T end)
+    {
+        mStart = start;
+        mEnd = end;
+    }
+
+
+    @Override
+    public boolean contains(T element)
+    {
+        return mStart.compareTo(element) <= 0 && mEnd.compareTo(element) >= 0;
+    }
+}

--- a/src/main/java/org/dmfs/jems/set/elementary/PredicateSet.java
+++ b/src/main/java/org/dmfs/jems/set/elementary/PredicateSet.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.set.elementary;
+
+import org.dmfs.jems.predicate.Predicate;
+import org.dmfs.jems.set.Set;
+
+
+/**
+ * A {@link Set} of all elements which satisfy a given {@link Predicate}.
+ *
+ * @author Marten Gajda
+ */
+public final class PredicateSet<T> implements Set<T>
+{
+    private final Predicate<T> mPredicate;
+
+
+    public PredicateSet(Predicate<T> predicate)
+    {
+        mPredicate = predicate;
+    }
+
+
+    @Override
+    public boolean contains(T element)
+    {
+        return mPredicate.satisfiedBy(element);
+    }
+}

--- a/src/test/java/org/dmfs/jems/set/elementary/IntervalTest.java
+++ b/src/test/java/org/dmfs/jems/set/elementary/IntervalTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.set.elementary;
+
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.set.SetContainsMatcher.contains;
+import static org.dmfs.jems.hamcrest.matchers.set.SetLacksMatcher.lacks;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Interval}.
+ *
+ * @author Marten Gajda
+ */
+public class IntervalTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new Interval<>(2, 1), lacks(0, 1, 2, 3));
+
+        assertThat(new Interval<>(1, 1),
+                allOf(
+                        contains(1),
+                        lacks(0, 2)));
+
+        assertThat(new Interval<>(1f, 2f),
+                allOf(
+                        contains(1f, 1.0001f, 1.9999f, 2f),
+                        lacks(0.99999f, 2.00001f)));
+    }
+}

--- a/src/test/java/org/dmfs/jems/set/elementary/PredicateSetTest.java
+++ b/src/test/java/org/dmfs/jems/set/elementary/PredicateSetTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.set.elementary;
+
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.set.SetContainsMatcher.contains;
+import static org.dmfs.jems.hamcrest.matchers.set.SetLacksMatcher.lacks;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link PredicateSet}.
+ *
+ * @author Marten Gajda
+ */
+public class PredicateSetTest
+{
+
+    @Test
+    public void test()
+    {
+        assertThat(new PredicateSet<>(i -> i > 3),
+                allOf(
+                        contains(4, 5, 6),
+                        lacks(1, 2, 3)));
+    }
+}


### PR DESCRIPTION
This commit adds a simple immutable `Set` type and a few basic implementations:
* `EmptySet` - A `Set` which doesn't contain any element.
* `SingletonSet` - A `Set` containing exactly one element.
* `SeqSet` - A `Set` containing the elements of an `Iterable`.
* `AdapterSet` - An adapter to Java's `Set` type.