### PR TITLE
Introduce simplified Optional implements #149

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ apply from: 'publish.gradle'
 apply from: 'jacoco.gradle'
 
 dependencies {
-    testCompile 'junit:junit:' + JUNIT
-    testCompile 'org.hamcrest:hamcrest-all:' + HAMCREST
-    testCompile project(":jems-testing")
+    testImplementation 'junit:junit:' + JUNIT
+    testImplementation 'org.hamcrest:hamcrest-all:' + HAMCREST
+    testImplementation project(":jems-testing")
 }

--- a/jems-testing/build.gradle
+++ b/jems-testing/build.gradle
@@ -16,4 +16,6 @@ dependencies {
     compile 'junit:junit:' + JUNIT
     compile 'org.hamcrest:hamcrest-all:' + HAMCREST
     compile 'org.mockito:mockito-core:' + MOCKITO
+
+    testImplementation 'org.hamcrest:hamcrest-all:' + HAMCREST
 }

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/AbsentMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/AbsentMatcher.java
@@ -33,7 +33,9 @@ import java.util.NoSuchElementException;
  *
  * @author Marten Gajda
  * @author Gabor Keszthelyi
+ * @deprecated in favour of {@link org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher}.
  */
+@Deprecated
 public final class AbsentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T>>
 {
     private final Single<T> mFallbackDummySingle;

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/PresentMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/PresentMatcher.java
@@ -29,7 +29,9 @@ import org.hamcrest.core.IsEqual;
  * A {@link Matcher} to match the presence and value of an {@link Optional}.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher}.
  */
+@Deprecated
 public final class PresentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T>>
 {
     public static <T> PresentMatcher<T> isPresent()

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/optional/AbsentMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/optional/AbsentMatcher.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.optional;
+
+import org.dmfs.jems.optional.Optional;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.NoSuchElementException;
+
+
+/**
+ * {@link Matcher} of {@link Optional} that matches when the tested value is absent.
+ *
+ * @author Marten Gajda
+ */
+public final class AbsentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T>>
+{
+    /**
+     * Creates a matcher that matches when the tested value is absent.
+     */
+    public static <T> AbsentMatcher<T> absent()
+    {
+        return new AbsentMatcher<T>();
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Optional<T> item, Description mismatchDescription)
+    {
+        if (item.isPresent())
+        {
+            mismatchDescription.appendText("present");
+            return false;
+        }
+
+        try
+        {
+            item.value();
+            mismatchDescription.appendText("value() did not throw NoSuchElementException");
+            return false;
+        }
+        catch (NoSuchElementException e)
+        {
+            return true;
+        }
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("absent");
+    }
+}

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/optional/PresentMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/optional/PresentMatcher.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.optional;
+
+import org.dmfs.jems.optional.Optional;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.hamcrest.core.IsAnything;
+import org.hamcrest.core.IsEqual;
+
+
+/**
+ * A {@link Matcher} to match the presence and value of an {@link Optional}.
+ *
+ * @author Marten Gajda
+ */
+public final class PresentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T>>
+{
+    private final Matcher<T> mDelegate;
+
+
+    public PresentMatcher()
+    {
+        this(new IsAnything<T>());
+    }
+
+
+    public PresentMatcher(T expected)
+    {
+        this(new IsEqual<>(expected));
+    }
+
+
+    public PresentMatcher(Matcher<T> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    public static <T> PresentMatcher<T> present()
+    {
+        return new PresentMatcher<>();
+    }
+
+
+    public static <T> PresentMatcher<T> present(T expectedValue)
+    {
+        return new PresentMatcher<>(expectedValue);
+    }
+
+
+    public static <T> PresentMatcher<T> present(Matcher<T> delegate)
+    {
+        return new PresentMatcher<>(delegate);
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Optional<T> item, Description mismatchDescription)
+    {
+        if (!item.isPresent())
+        {
+            mismatchDescription.appendText("not present");
+            return false;
+        }
+
+        if (!mDelegate.matches(item.value()))
+        {
+            mismatchDescription.appendText("present, but value ");
+            mDelegate.describeMismatch(item.value(), mismatchDescription);
+            return false;
+        }
+
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("present with value ");
+        mDelegate.describeTo(description);
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/optional/AbsentMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/optional/AbsentMatcherTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.optional;
+
+import org.dmfs.jems.optional.Optional;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.NoSuchElementException;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.object.HasToString.hasToString;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test for {@link AbsentMatcher}.
+ *
+ * @author Marten Gajda
+ */
+public final class AbsentMatcherTest
+{
+    @Test
+    public void test_absent_noArg()
+    {
+        assertThat(AbsentMatcher.absent().matchesSafely(new RegularAbsent<>(), desc()), is(true));
+
+        assertThat(AbsentMatcher.<String>absent().matchesSafely(new RegularPresent<>("3"), desc()), is(false));
+        assertThat(AbsentMatcher.<Date>absent().matchesSafely(new BrokenAbsent(), desc()), is(false));
+        assertThat(AbsentMatcher.<Date>absent().matchesSafely(new BrokenPresent<>(), desc()), is(false));
+    }
+
+
+    @Test
+    public void testPresenceMismatchDescription() throws Exception
+    {
+        Description mismatchMsg = new StringDescription();
+        new AbsentMatcher<>().describeMismatch(new RegularPresent<>("3"), mismatchMsg);
+        assertThat(mismatchMsg.toString(), CoreMatchers.is("present"));
+    }
+
+
+    @Test
+    public void testDescribeTo() throws Exception
+    {
+        Description description = new StringDescription();
+        new AbsentMatcher<>().describeTo(description);
+        assertThat(description, hasToString("absent"));
+    }
+
+
+    private Description.NullDescription desc()
+    {
+        return new Description.NullDescription();
+    }
+
+
+    private static final class BrokenAbsent implements Optional<Date>
+    {
+        @Override
+        public boolean isPresent()
+        {
+            return false;
+        }
+
+
+        @Override
+        public Date value() throws NoSuchElementException
+        {
+            return new Date();
+        }
+    }
+
+
+    private static final class BrokenPresent<T> implements Optional<T>
+    {
+
+        @Override
+        public boolean isPresent()
+        {
+            return true;
+        }
+
+
+        @Override
+        public T value() throws NoSuchElementException
+        {
+            throw new NoSuchElementException();
+        }
+    }
+
+
+    private static final class RegularAbsent<T> implements Optional<T>
+    {
+        @Override
+        public boolean isPresent()
+        {
+            return false;
+        }
+
+
+        @Override
+        public T value() throws NoSuchElementException
+        {
+            throw new NoSuchElementException();
+        }
+    }
+
+
+    private static final class RegularPresent<T> implements Optional<T>
+    {
+        private final T mValue;
+
+
+        private RegularPresent(T value)
+        {
+            mValue = value;
+        }
+
+
+        @Override
+        public boolean isPresent()
+        {
+            return true;
+        }
+
+
+        @Override
+        public T value() throws NoSuchElementException
+        {
+            return mValue;
+        }
+    }
+
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/optional/PresentMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/optional/PresentMatcherTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.optional;
+
+import org.dmfs.jems.optional.elementary.Present;
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.dmfs.jems.optional.elementary.Absent.absent;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.object.HasToString.hasToString;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test for {@link PresentMatcher}.
+ *
+ * @author Marten Gajda
+ */
+public class PresentMatcherTest
+{
+    @Test
+    public void testMatchesSafely() throws Exception
+    {
+        assertThat(new PresentMatcher<>().matchesSafely(absent(), new Description.NullDescription()), is(false));
+        assertThat(new PresentMatcher<String>().matchesSafely(new Present<>("test"), new Description.NullDescription()), is(true));
+        assertThat(new PresentMatcher<>("test").matchesSafely(new Present<>("test"), new Description.NullDescription()), is(true));
+        assertThat(new PresentMatcher<>("test").matchesSafely(new Present<>("tost"), new Description.NullDescription()), is(false));
+
+        assertThat(present().matchesSafely(new Present<>("test"), new Description.NullDescription()), is(true));
+        assertThat(present("test").matchesSafely(new Present<>("test"), new Description.NullDescription()), is(true));
+        assertThat(present(is("test")).matchesSafely(new Present<>("test"), new Description.NullDescription()), is(true));
+
+        assertThat(present("tost").matchesSafely(new Present<>("test"), new Description.NullDescription()), is(false));
+        assertThat(present(is("tost")).matchesSafely(new Present<>("test"), new Description.NullDescription()), is(false));
+    }
+
+
+    @Test
+    public void testValueMismatchDescription() throws Exception
+    {
+        Description mismatchMsg = new StringDescription();
+        new PresentMatcher<>("123").describeMismatch(new Present<>("abc"), mismatchMsg);
+        assertThat(mismatchMsg.toString(), is("present, but value was \"abc\""));
+    }
+
+
+    @Test
+    public void testPresenceMismatchDescription() throws Exception
+    {
+        Description mismatchMsg = new StringDescription();
+        new PresentMatcher<>("123").describeMismatch(absent(), mismatchMsg);
+        assertThat(mismatchMsg.toString(), is("not present"));
+    }
+
+
+    @Test
+    public void testDescribeTo() throws Exception
+    {
+        Description description = new StringDescription();
+        new PresentMatcher<>("123").describeTo(description);
+        assertThat(description, hasToString("present with value \"123\""));
+    }
+
+}

--- a/src/main/java/org/dmfs/iterables/elementary/OptionalIterable.java
+++ b/src/main/java/org/dmfs/iterables/elementary/OptionalIterable.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.iterables.elementary;
+
+import org.dmfs.iterators.EmptyIterator;
+import org.dmfs.jems.optional.Optional;
+
+import java.util.Iterator;
+
+
+/**
+ * An {@link Iterable} which iterates the elements of an {@link Optional} {@link Iterable} or nothing if the Optional is not present.
+ *
+ * @author Marten Gajda
+ */
+public final class OptionalIterable<T> implements Iterable<T>
+{
+    private final Optional<? extends Iterable<T>> mDelegate;
+
+
+    public OptionalIterable(Optional<? extends Iterable<T>> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public Iterator<T> iterator()
+    {
+        return mDelegate.isPresent() ? mDelegate.value().iterator() : EmptyIterator.instance();
+    }
+}

--- a/src/main/java/org/dmfs/iterables/elementary/PresentValues.java
+++ b/src/main/java/org/dmfs/iterables/elementary/PresentValues.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.iterables.elementary;
+
+import org.dmfs.iterables.SingletonIterable;
+import org.dmfs.jems.optional.Optional;
+
+import java.util.Iterator;
+
+
+/**
+ * {@link Iterable} which iterates over the present values from the input {@link Iterable} of {@link Optional}s of {@code E}.
+ *
+ * @author Gabor Keszthelyi
+ * @author Marten Gajda
+ */
+public final class PresentValues<E> implements Iterable<E>
+{
+    private final Iterable<Optional<E>> mOptionals;
+
+
+    public PresentValues(Optional<E> optional)
+    {
+        this(new SingletonIterable<>(optional));
+    }
+
+
+    @SafeVarargs
+    public PresentValues(Optional<E>... optionals)
+    {
+        this(new Seq<>(optionals));
+    }
+
+
+    public PresentValues(Iterable<Optional<E>> optionals)
+    {
+        mOptionals = optionals;
+    }
+
+
+    @Override
+    public Iterator<E> iterator()
+    {
+        return new org.dmfs.iterators.elementary.PresentValues<>(mOptionals.iterator());
+    }
+}

--- a/src/main/java/org/dmfs/iterators/elementary/PresentValues.java
+++ b/src/main/java/org/dmfs/iterators/elementary/PresentValues.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.iterators.elementary;
+
+import org.dmfs.iterators.AbstractBaseIterator;
+import org.dmfs.iterators.SingletonIterator;
+import org.dmfs.iterators.decorators.Filtered;
+import org.dmfs.jems.optional.Optional;
+
+import java.util.Iterator;
+
+
+/**
+ * {@link Iterator} that iterates over the present values from the input {@link Iterator} of {@link Optional}s of {@code E}.
+ *
+ * @author Marten Gajda
+ */
+public final class PresentValues<E> extends AbstractBaseIterator<E>
+{
+    private final Iterator<Optional<E>> mDelegate;
+
+
+    public PresentValues(Optional<E> optional)
+    {
+        this(new SingletonIterator<>(optional));
+    }
+
+
+    @SafeVarargs
+    public PresentValues(Optional<E>... optionals)
+    {
+        this(new Seq<>(optionals));
+    }
+
+
+    public PresentValues(Iterator<Optional<E>> optionals)
+    {
+        mDelegate = new Filtered<>(optionals, Optional::isPresent);
+    }
+
+
+    @Override
+    public boolean hasNext()
+    {
+        return mDelegate.hasNext();
+    }
+
+
+    @Override
+    public E next()
+    {
+        return mDelegate.next().value();
+    }
+}

--- a/src/main/java/org/dmfs/jems/optional/Optional.java
+++ b/src/main/java/org/dmfs/jems/optional/Optional.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional;
+
+import java.util.NoSuchElementException;
+
+
+/**
+ * An optional value. In contrast to Java's {@code Optional} this an interface, so custom implementations can be developed.
+ *
+ * @param <T>
+ *         the type of the value.
+ *
+ * @author Marten Gajda
+ */
+public interface Optional<T>
+{
+    /**
+     * Returns whether the optional value is present.
+     *
+     * @return {@code true} if the value is present, {@code false} otherwise.
+     */
+    boolean isPresent();
+
+    /**
+     * Returns the optional value.
+     *
+     * @return The value.
+     *
+     * @throws NoSuchElementException
+     *         if the optional value is not present.
+     */
+    T value() throws NoSuchElementException;
+}

--- a/src/main/java/org/dmfs/jems/optional/adapters/Collapsed.java
+++ b/src/main/java/org/dmfs/jems/optional/adapters/Collapsed.java
@@ -17,11 +17,9 @@
 
 package org.dmfs.jems.optional.adapters;
 
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 import java.util.NoSuchElementException;
-
-import static org.dmfs.optional.Absent.absent;
 
 
 /**
@@ -30,7 +28,7 @@ import static org.dmfs.optional.Absent.absent;
  * @author Marten Gajda
  * @author Gabor Keszthelyi
  */
-public final class Collapsed<T> implements Optional<T>
+public final class Collapsed<T> implements org.dmfs.optional.Optional<T>
 {
     private final Optional<Optional<T>> mDelegate;
 
@@ -44,14 +42,14 @@ public final class Collapsed<T> implements Optional<T>
     @Override
     public boolean isPresent()
     {
-        return mDelegate.value(absent()).isPresent();
+        return mDelegate.isPresent() && mDelegate.value().isPresent();
     }
 
 
     @Override
     public T value(T defaultValue)
     {
-        return mDelegate.value(absent()).value(defaultValue);
+        return isPresent() ? value() : defaultValue;
     }
 
 

--- a/src/main/java/org/dmfs/jems/optional/adapters/Conditional.java
+++ b/src/main/java/org/dmfs/jems/optional/adapters/Conditional.java
@@ -29,8 +29,7 @@ import static org.dmfs.optional.Absent.absent;
 
 
 /**
- * {@link Optional} that is present with the value of the provided target if it satisfies the given {@link Predicate},
- * otherwise it is absent.
+ * {@link Optional} that is present with the value of the provided target if it satisfies the given {@link Predicate}, otherwise it is absent.
  *
  * @author Gabor Keszthelyi
  */

--- a/src/main/java/org/dmfs/jems/optional/adapters/First.java
+++ b/src/main/java/org/dmfs/jems/optional/adapters/First.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.dmfs.iterables.decorators.Filtered;
+import org.dmfs.iterables.decorators.Sieved;
+import org.dmfs.iterators.Filter;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Absent;
+import org.dmfs.jems.optional.elementary.Present;
+import org.dmfs.jems.predicate.Predicate;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+
+/**
+ * The first value of an {@link Iterable}.
+ *
+ * @author Marten Gajda
+ */
+public final class First<T> implements Optional<T>
+{
+    private final Iterable<T> mIterable;
+    private Optional<T> mDelegate;
+
+
+    /**
+     * Creates an {@link Optional} of the first value of the given {@link Iterable} which matches the given {@link Predicate}.
+     *
+     * @param iterable
+     *         The {@link Iterable}
+     * @param predicate
+     *         The {@link Predicate}
+     */
+    public First(Iterable<T> iterable, Predicate<T> predicate)
+    {
+        this(new Sieved<T>(predicate, iterable));
+    }
+
+
+    /**
+     * Creates an {@link Optional} of the first value of the given {@link Iterable} which matches the given {@link Filter}.
+     *
+     * @param iterable
+     *         The {@link Iterable}
+     * @param filter
+     *         The {@link Filter}
+     */
+    public First(Iterable<T> iterable, Filter<T> filter)
+    {
+        this(new Filtered<T>(iterable, filter));
+    }
+
+
+    /**
+     * Creates the {@link Optional} first value of the given {@link Iterable}.
+     *
+     * @param iterable
+     *         A {@link Iterable}.
+     */
+    public First(Iterable<T> iterable)
+    {
+        mIterable = iterable;
+    }
+
+
+    @Override
+    public boolean isPresent()
+    {
+        return delegate().isPresent();
+    }
+
+
+    @Override
+    public T value() throws NoSuchElementException
+    {
+        return delegate().value();
+    }
+
+
+    private Optional<T> delegate()
+    {
+        if (mDelegate == null)
+        {
+            Iterator<T> iterator = mIterable.iterator();
+            mDelegate = iterator.hasNext() ? new Present<>(iterator.next()) : Absent.<T>absent();
+        }
+        return mDelegate;
+    }
+}

--- a/src/main/java/org/dmfs/jems/optional/adapters/FirstPresent.java
+++ b/src/main/java/org/dmfs/jems/optional/adapters/FirstPresent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.dmfs.iterables.elementary.PresentValues;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.decorators.DelegatingOptional;
+
+
+/**
+ * The first present value of an {@link Iterable} of {@link Optional}s.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class FirstPresent<T> extends DelegatingOptional<T>
+{
+    @SafeVarargs
+    public FirstPresent(Optional<T>... optionals)
+    {
+        this(new Seq<>(optionals));
+    }
+
+
+    public FirstPresent(Iterable<Optional<T>> optionals)
+    {
+        super(new First<>(new PresentValues<>(optionals)));
+    }
+}

--- a/src/main/java/org/dmfs/jems/optional/adapters/MapEntry.java
+++ b/src/main/java/org/dmfs/jems/optional/adapters/MapEntry.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.dmfs.jems.optional.Optional;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+
+/**
+ * An {@link Optional} element of a {@link Map}. This is present if the given {@link Map} contains a non-{@code null} value for the given key.
+ *
+ * @author Marten Gajda
+ */
+public final class MapEntry<K, V> implements Optional<V>
+{
+    private final Map<K, V> mMap;
+    private final K mKey;
+
+
+    public MapEntry(Map<K, V> map, K key)
+    {
+        mMap = map;
+        mKey = key;
+    }
+
+
+    @Override
+    public boolean isPresent()
+    {
+        return mMap.get(mKey) != null;
+    }
+
+
+    @Override
+    public V value() throws NoSuchElementException
+    {
+        V value = mMap.get(mKey);
+        if (value == null)
+        {
+            throw new NoSuchElementException(String.format("No element for key \"%s\" found", mKey.toString()));
+        }
+        return value;
+    }
+}

--- a/src/main/java/org/dmfs/jems/optional/adapters/Next.java
+++ b/src/main/java/org/dmfs/jems/optional/adapters/Next.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Absent;
+import org.dmfs.jems.optional.elementary.Present;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+
+/**
+ * The next value of an {@link Iterator}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class Next<E> implements Optional<E>
+{
+    private final Iterator<E> mIterator;
+
+    private Optional<E> mDelegate;
+
+
+    public Next(Iterator<E> iterator)
+    {
+        mIterator = iterator;
+    }
+
+
+    @Override
+    public boolean isPresent()
+    {
+        return cachedDelegate().isPresent();
+    }
+
+
+    @Override
+    public E value() throws NoSuchElementException
+    {
+        return cachedDelegate().value();
+    }
+
+
+    private Optional<E> cachedDelegate()
+    {
+        if (mDelegate == null)
+        {
+            mDelegate = mIterator.hasNext() ? new Present<E>(mIterator.next()) : Absent.<E>absent();
+        }
+        return mDelegate;
+    }
+
+}

--- a/src/main/java/org/dmfs/jems/optional/adapters/NextPresent.java
+++ b/src/main/java/org/dmfs/jems/optional/adapters/NextPresent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.dmfs.iterators.elementary.PresentValues;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.decorators.DelegatingOptional;
+
+import java.util.Iterator;
+
+
+/**
+ * The next present value in the given {@link Iterator} of {@link Optional}s.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class NextPresent<T> extends DelegatingOptional<T>
+{
+    public NextPresent(Iterator<Optional<T>> optionals)
+    {
+        super(new Next<>(new PresentValues<>(optionals)));
+    }
+}

--- a/src/main/java/org/dmfs/jems/optional/adapters/SinglePresent.java
+++ b/src/main/java/org/dmfs/jems/optional/adapters/SinglePresent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.single.Single;
+
+import java.util.NoSuchElementException;
+
+
+/**
+ * A present {@link Optional} that takes a {@link Single} for the value.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class SinglePresent<T> implements Optional<T>
+{
+    private final Single<T> mSingle;
+
+
+    public SinglePresent(Single<T> single)
+    {
+        mSingle = single;
+    }
+
+
+    @Override
+    public boolean isPresent()
+    {
+        return true;
+    }
+
+
+    @Override
+    public T value() throws NoSuchElementException
+    {
+        return mSingle.value();
+    }
+}

--- a/src/main/java/org/dmfs/jems/optional/composite/Zipped.java
+++ b/src/main/java/org/dmfs/jems/optional/composite/Zipped.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.composite;
+
+import org.dmfs.jems.function.BiFunction;
+import org.dmfs.jems.optional.Optional;
+
+import java.util.NoSuchElementException;
+
+
+/**
+ * An {@link Optional} which combines two other {@link Optional}s with a {@link BiFunction} if they are both present and is absent otherwise
+ *
+ * @author Marten Gajda
+ */
+public final class Zipped<Left, Right, Result> implements Optional<Result>
+{
+    private final Optional<Left> mLeft;
+    private final Optional<Right> mRight;
+    private final BiFunction<Left, Right, Result> mFunction;
+
+
+    public Zipped(Optional<Left> left, Optional<Right> right, BiFunction<Left, Right, Result> function)
+    {
+        mLeft = left;
+        mRight = right;
+        mFunction = function;
+    }
+
+
+    @Override
+    public boolean isPresent()
+    {
+        return mLeft.isPresent() && mRight.isPresent();
+    }
+
+
+    @Override
+    public Result value() throws NoSuchElementException
+    {
+        return mFunction.value(mLeft.value(), mRight.value());
+    }
+}

--- a/src/main/java/org/dmfs/jems/optional/decorators/DelegatingOptional.java
+++ b/src/main/java/org/dmfs/jems/optional/decorators/DelegatingOptional.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.decorators;
+
+import org.dmfs.jems.optional.Optional;
+
+import java.util.NoSuchElementException;
+
+
+/**
+ * An abstract {@link Optional} which delegates all method calls to another given {@link Optional}.
+ * <p>
+ * This class is abstract and is meant to be a convenient way of composing {@link Optional}s despite the lack of native support for the decoration pattern in
+ * Java.
+ *
+ * @author Marten Gajda
+ */
+public abstract class DelegatingOptional<T> implements Optional<T>
+{
+    private final Optional<T> mDelegate;
+
+
+    public DelegatingOptional(Optional<T> delegate)
+    {
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public final boolean isPresent()
+    {
+        return mDelegate.isPresent();
+    }
+
+
+    @Override
+    public final T value() throws NoSuchElementException
+    {
+        return mDelegate.value();
+    }
+}

--- a/src/main/java/org/dmfs/jems/optional/decorators/MapCollapsed.java
+++ b/src/main/java/org/dmfs/jems/optional/decorators/MapCollapsed.java
@@ -18,8 +18,8 @@
 package org.dmfs.jems.optional.decorators;
 
 import org.dmfs.jems.function.Function;
+import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.adapters.Collapsed;
-import org.dmfs.optional.Optional;
 import org.dmfs.optional.decorators.DelegatingOptional;
 
 

--- a/src/main/java/org/dmfs/jems/optional/decorators/Mapped.java
+++ b/src/main/java/org/dmfs/jems/optional/decorators/Mapped.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.optional.decorators;
 
 import org.dmfs.jems.function.Function;
-import org.dmfs.optional.Optional;
+import org.dmfs.jems.optional.Optional;
 
 import java.util.NoSuchElementException;
 
@@ -28,7 +28,7 @@ import java.util.NoSuchElementException;
  *
  * @author Gabor Keszthelyi
  */
-public final class Mapped<From, To> implements Optional<To>
+public final class Mapped<From, To> implements org.dmfs.optional.Optional<To>
 {
     private final Optional<From> mFromValue;
     private final Function<From, To> mConversion;

--- a/src/main/java/org/dmfs/jems/optional/decorators/Sieved.java
+++ b/src/main/java/org/dmfs/jems/optional/decorators/Sieved.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.decorators;
+
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.predicate.Predicate;
+
+import java.util.NoSuchElementException;
+
+
+/**
+ * {@link Optional} decorator which is present if the delegate is present and satisfies a specific {@link Predicate}.
+ *
+ * @author Marten Gajda
+ */
+public final class Sieved<T> implements Optional<T>
+{
+    private final Predicate<T> mPredicate;
+    private final Optional<T> mDelegate;
+
+
+    public Sieved(Predicate<T> predicate, Optional<T> delegate)
+    {
+        mPredicate = predicate;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public boolean isPresent()
+    {
+        return mDelegate.isPresent() && mPredicate.satisfiedBy(mDelegate.value());
+    }
+
+
+    @Override
+    public T value() throws NoSuchElementException
+    {
+        T value = mDelegate.value();
+        if (!mPredicate.satisfiedBy(value))
+        {
+            throw new NoSuchElementException("Delegate sieved.");
+        }
+        return value;
+    }
+}

--- a/src/main/java/org/dmfs/jems/optional/elementary/Absent.java
+++ b/src/main/java/org/dmfs/jems/optional/elementary/Absent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.elementary;
+
+import org.dmfs.jems.optional.Optional;
+
+import java.util.NoSuchElementException;
+
+
+/**
+ * An {@link Optional} value that's never present.
+ *
+ * @author Marten Gajda
+ */
+public final class Absent<T> implements Optional<T>
+{
+    private final static Optional<?> INSTANCE = new Absent<Void>();
+
+
+    /**
+     * Returns an {@link Absent} value.
+     *
+     * @param <T>
+     *         The type of the absent value.
+     *
+     * @return An {@link Absent} of the given type.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Absent<T> absent()
+    {
+        return (Absent<T>) INSTANCE;
+    }
+
+
+    @Override
+    public boolean isPresent()
+    {
+        return false;
+    }
+
+
+    @Override
+    public T value() throws NoSuchElementException
+    {
+        throw new NoSuchElementException("No value is present in this Optional. Better call isPresent() next time.");
+    }
+}

--- a/src/main/java/org/dmfs/jems/optional/elementary/NullSafe.java
+++ b/src/main/java/org/dmfs/jems/optional/elementary/NullSafe.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.elementary;
+
+import org.dmfs.jems.optional.Optional;
+
+import java.util.NoSuchElementException;
+
+
+/**
+ * An {@link Optional} that's not present if the given value is {@code null}.
+ *
+ * @author Marten Gajda
+ */
+public final class NullSafe<T> implements Optional<T>
+{
+    private final T mValue;
+
+
+    public NullSafe(T value)
+    {
+        mValue = value;
+    }
+
+
+    @Override
+    public boolean isPresent()
+    {
+        return mValue != null;
+    }
+
+
+    @Override
+    public T value() throws NoSuchElementException
+    {
+        if (mValue == null)
+        {
+            throw new NoSuchElementException("The value of this Optional is not present.");
+        }
+        return mValue;
+    }
+}

--- a/src/main/java/org/dmfs/jems/optional/elementary/Present.java
+++ b/src/main/java/org/dmfs/jems/optional/elementary/Present.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.elementary;
+
+import org.dmfs.jems.optional.Optional;
+
+import java.util.NoSuchElementException;
+
+
+/**
+ * A special {@link Optional} that's always present. As a consequence this doesn't take {@code null} values.
+ *
+ * @author Marten Gajda
+ */
+public final class Present<T> implements Optional<T>
+{
+    private final T mValue;
+
+
+    public Present(T value)
+    {
+        if (value == null)
+        {
+            throw new IllegalArgumentException("A Present value can't be null");
+        }
+        mValue = value;
+    }
+
+
+    @Override
+    public boolean isPresent()
+    {
+        return true;
+    }
+
+
+    @Override
+    public T value() throws NoSuchElementException
+    {
+        return mValue;
+    }
+}

--- a/src/main/java/org/dmfs/jems/single/combined/Backed.java
+++ b/src/main/java/org/dmfs/jems/single/combined/Backed.java
@@ -17,9 +17,9 @@
 
 package org.dmfs.jems.single.combined;
 
+import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.single.Single;
 import org.dmfs.jems.single.elementary.ValueSingle;
-import org.dmfs.optional.Optional;
 
 
 /**

--- a/src/main/java/org/dmfs/optional/Absent.java
+++ b/src/main/java/org/dmfs/optional/Absent.java
@@ -23,7 +23,9 @@ import java.util.NoSuchElementException;
  * An {@link Optional} value that's never present.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.jems.optional.elementary.Absent}.
  */
+@Deprecated
 public final class Absent<T> implements Optional<T>
 {
     private final static Optional<?> INSTANCE = new Absent<Void>();

--- a/src/main/java/org/dmfs/optional/First.java
+++ b/src/main/java/org/dmfs/optional/First.java
@@ -30,7 +30,9 @@ import java.util.NoSuchElementException;
  * The first value of an {@link Iterable}.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.jems.optional.adapters.First}.
  */
+@Deprecated
 public final class First<T> implements Optional<T>
 {
     private final Iterable<T> mIterable;

--- a/src/main/java/org/dmfs/optional/Next.java
+++ b/src/main/java/org/dmfs/optional/Next.java
@@ -25,7 +25,9 @@ import java.util.NoSuchElementException;
  * The next value of an {@link Iterator}.
  *
  * @author Gabor Keszthelyi
+ * @deprecated in favour of {@link org.dmfs.jems.optional.adapters.Next}
  */
+@Deprecated
 public final class Next<E> implements Optional<E>
 {
     private final Iterator<E> mIterator;

--- a/src/main/java/org/dmfs/optional/NullSafe.java
+++ b/src/main/java/org/dmfs/optional/NullSafe.java
@@ -23,7 +23,9 @@ import java.util.NoSuchElementException;
  * An {@link Optional} that's not present if the given value is {@code null}.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.jems.optional.elementary.NullSafe}.
  */
+@Deprecated
 public final class NullSafe<T> implements Optional<T>
 {
     private final T mValue;

--- a/src/main/java/org/dmfs/optional/Optional.java
+++ b/src/main/java/org/dmfs/optional/Optional.java
@@ -16,9 +16,6 @@
 
 package org.dmfs.optional;
 
-import java.util.NoSuchElementException;
-
-
 /**
  * An optional value. In contrast to Java's {@code Optional} this an interface, so custom implementations can be developed.
  *
@@ -26,15 +23,11 @@ import java.util.NoSuchElementException;
  *         the type of the value.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.jems.optional.Optional}.
  */
-public interface Optional<T>
+@Deprecated
+public interface Optional<T> extends org.dmfs.jems.optional.Optional<T>
 {
-    /**
-     * Returns whether the optional value is present.
-     *
-     * @return {@code true} if the value is present, {@code false} otherwise.
-     */
-    boolean isPresent();
 
     /**
      * Returns the optional value or the given default value if the optional value is not present.
@@ -46,13 +39,4 @@ public interface Optional<T>
      */
     T value(T defaultValue);
 
-    /**
-     * Returns the optional value.
-     *
-     * @return The value.
-     *
-     * @throws NoSuchElementException
-     *         if the optional value is not present.
-     */
-    T value() throws NoSuchElementException;
 }

--- a/src/main/java/org/dmfs/optional/Present.java
+++ b/src/main/java/org/dmfs/optional/Present.java
@@ -23,7 +23,9 @@ import java.util.NoSuchElementException;
  * A special {@link Optional} that's always present. As a consequence this doesn't take {@code null} values.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.jems.optional.elementary.Present}.
  */
+@Deprecated
 public final class Present<T> implements Optional<T>
 {
     private final T mValue;

--- a/src/main/java/org/dmfs/optional/adapters/FirstPresent.java
+++ b/src/main/java/org/dmfs/optional/adapters/FirstPresent.java
@@ -28,7 +28,9 @@ import org.dmfs.optional.iterable.PresentValues;
  * The first present value of an {@link Iterable} of {@link Optional}s.
  *
  * @author Gabor Keszthelyi
+ * @deprecated in favour of {@link org.dmfs.jems.optional.adapters.FirstPresent}.
  */
+@Deprecated
 public final class FirstPresent<T> extends DelegatingOptional<T>
 {
     @SafeVarargs

--- a/src/main/java/org/dmfs/optional/adapters/MapEntry.java
+++ b/src/main/java/org/dmfs/optional/adapters/MapEntry.java
@@ -27,7 +27,9 @@ import java.util.NoSuchElementException;
  * An {@link Optional} element of a {@link Map}. This is present if the given {@link Map} contains a non-{@code null} value for the given key.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.jems.optional.adapters.MapEntry}.
  */
+@Deprecated
 public final class MapEntry<K, V> implements Optional<V>
 {
     private final Map<K, V> mMap;

--- a/src/main/java/org/dmfs/optional/adapters/NextPresent.java
+++ b/src/main/java/org/dmfs/optional/adapters/NextPresent.java
@@ -29,7 +29,9 @@ import java.util.Iterator;
  * The next present value in the given {@link Iterator} of {@link Optional}s.
  *
  * @author Gabor Keszthelyi
+ * @deprecated in favour of {@link org.dmfs.jems.optional.adapters.NextPresent}.
  */
+@Deprecated
 public final class NextPresent<T> extends DelegatingOptional<T>
 {
     public NextPresent(Iterator<Optional<T>> optionals)

--- a/src/main/java/org/dmfs/optional/adapters/SinglePresent.java
+++ b/src/main/java/org/dmfs/optional/adapters/SinglePresent.java
@@ -27,7 +27,9 @@ import java.util.NoSuchElementException;
  * A present {@link Optional} that takes a {@link Single} for the value.
  *
  * @author Gabor Keszthelyi
+ * @deprecated in favour of {@link org.dmfs.jems.optional.adapters.SinglePresent}.
  */
+@Deprecated
 public final class SinglePresent<T> implements Optional<T>
 {
     private final Single<T> mSingle;

--- a/src/main/java/org/dmfs/optional/composite/Zipped.java
+++ b/src/main/java/org/dmfs/optional/composite/Zipped.java
@@ -27,7 +27,9 @@ import java.util.NoSuchElementException;
  * An {@link Optional} which combines two other {@link Optional}s with a {@link BiFunction} if they are both present and is absent otherwise
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.jems.optional.composite.Zipped}.
  */
+@Deprecated
 public final class Zipped<Left, Right, Result> implements Optional<Result>
 {
     private final Optional<Left> mLeft;

--- a/src/main/java/org/dmfs/optional/decorators/DelegatingOptional.java
+++ b/src/main/java/org/dmfs/optional/decorators/DelegatingOptional.java
@@ -29,7 +29,9 @@ import java.util.NoSuchElementException;
  * Java.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.jems.optional.decorators.DelegatingOptional}.
  */
+@Deprecated
 public abstract class DelegatingOptional<T> implements Optional<T>
 {
     private final Optional<T> mDelegate;

--- a/src/main/java/org/dmfs/optional/decorators/Sieved.java
+++ b/src/main/java/org/dmfs/optional/decorators/Sieved.java
@@ -27,7 +27,9 @@ import java.util.NoSuchElementException;
  * {@link Optional} decorator which is present if the delegate is present and satisfies a specific {@link Predicate}.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.jems.optional.decorators.Sieved}.
  */
+@Deprecated
 public final class Sieved<T> implements Optional<T>
 {
     private final Predicate<T> mPredicate;

--- a/src/main/java/org/dmfs/optional/iterable/OptionalIterable.java
+++ b/src/main/java/org/dmfs/optional/iterable/OptionalIterable.java
@@ -27,7 +27,9 @@ import java.util.Iterator;
  * An {@link Iterable} which iterates the elements of an {@link Optional} {@link Iterable} or nothing if the Optional is not present.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.iterables.elementary.OptionalIterable}.
  */
+@Deprecated
 public final class OptionalIterable<T> implements Iterable<T>
 {
     private final Optional<? extends Iterable<T>> mDelegate;

--- a/src/main/java/org/dmfs/optional/iterable/PresentValues.java
+++ b/src/main/java/org/dmfs/optional/iterable/PresentValues.java
@@ -29,7 +29,9 @@ import java.util.Iterator;
  *
  * @author Gabor Keszthelyi
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.iterables.elementary.PresentValues}.
  */
+@Deprecated
 public final class PresentValues<E> implements Iterable<E>
 {
     private final Iterable<Optional<E>> mOptionals;

--- a/src/main/java/org/dmfs/optional/iterator/PresentValues.java
+++ b/src/main/java/org/dmfs/optional/iterator/PresentValues.java
@@ -32,7 +32,9 @@ import java.util.Iterator;
  *
  * @author Gabor Keszthelyi
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.iterators.elementary.PresentValues}.
  */
+@Deprecated
 public final class PresentValues<E> extends AbstractBaseIterator<E>
 {
     private final Iterator<Optional<E>> mDelegate;

--- a/src/test/java/org/dmfs/iterables/elementary/OptionalIterableTest.java
+++ b/src/test/java/org/dmfs/iterables/elementary/OptionalIterableTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.iterables.elementary;
+
+import org.dmfs.jems.optional.elementary.Present;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.dmfs.jems.optional.elementary.Absent.absent;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link OptionalIterable}.
+ *
+ * @author Marten Gajda
+ */
+public class OptionalIterableTest
+{
+    @Test
+    public void testIterator() throws Exception
+    {
+        assertThat(new OptionalIterable<>(absent()), emptyIterable());
+        assertThat(new OptionalIterable<>(new Present<>(new Seq<>())), Matchers.emptyIterable());
+        assertThat(new OptionalIterable<>(new Present<>(new Seq<>("1"))), iteratesTo("1"));
+        assertThat(new OptionalIterable<>(new Present<>(new Seq<>("1", "2"))), iteratesTo("1", "2"));
+    }
+}

--- a/src/test/java/org/dmfs/iterables/elementary/PresentValuesTest.java
+++ b/src/test/java/org/dmfs/iterables/elementary/PresentValuesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.iterables.elementary;
+
+import org.dmfs.jems.optional.elementary.Present;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.dmfs.jems.optional.elementary.Absent.absent;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link PresentValues}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public class PresentValuesTest
+{
+
+    @Test
+    public void test()
+    {
+        assertThat(
+                new PresentValues<>(
+                        new Seq<>(
+                                new Present<>("1"),
+                                absent(),
+                                absent(),
+                                new Present<>("2"),
+                                new Present<>("3"),
+                                absent())),
+                iteratesTo("1", "2", "3"));
+    }
+
+
+    @Test
+    public void testCtors()
+    {
+        assertThat(new PresentValues<>(), emptyIterable());
+        assertThat(new PresentValues<>(absent()), emptyIterable());
+        assertThat(new PresentValues<>(new Present<>("test")), iteratesTo("test"));
+        assertThat(new PresentValues<>(new Present<>("1"), new Present<>("2")), iteratesTo("1", "2"));
+        assertThat(new PresentValues<>(absent(), absent(), absent(), new Present<>("1"), new Present<>("2")), iteratesTo("1", "2"));
+    }
+}

--- a/src/test/java/org/dmfs/iterators/elementary/PresentValuesTest.java
+++ b/src/test/java/org/dmfs/iterators/elementary/PresentValuesTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.iterators.elementary;
+
+import org.dmfs.iterators.EmptyIterator;
+import org.dmfs.iterators.SingletonIterator;
+import org.dmfs.jems.optional.elementary.Absent;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Present;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ * Unit test for {@link PresentValues}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class PresentValuesTest
+{
+
+    private static final Absent<String> ABSENT = Absent.absent();
+
+
+    @Test
+    public void test_whenEmptyInput_noElement()
+    {
+        assertFalse(new PresentValues<>(EmptyIterator.<Optional<String>>instance()).hasNext());
+    }
+
+
+    @Test
+    public void test_whenOnePresentValue()
+    {
+        Iterator<Optional<String>> iterator = new SingletonIterator<Optional<String>>(new Present<>("hello"));
+
+        PresentValues<String> result = new PresentValues<>(iterator);
+
+        assertTrue(result.hasNext());
+        assertEquals("hello", result.next());
+        assertFalse(result.hasNext());
+    }
+
+
+    @Test
+    public void test_whenOneAbsentValue()
+    {
+        Iterator<Optional<String>> iterator = new SingletonIterator<Optional<String>>(Absent.<String>absent());
+
+        PresentValues<String> result = new PresentValues<>(iterator);
+
+        assertFalse(result.hasNext());
+    }
+
+
+    @Test
+    public void test_various()
+    {
+        Iterator<Optional<String>> iterator = new Seq<>(
+                new Present<>("1"),
+                ABSENT,
+                ABSENT,
+                new Present<>("2"),
+                new Present<>("3"),
+                ABSENT
+        );
+
+        PresentValues<String> result = new PresentValues<>(iterator);
+
+        assertTrue(result.hasNext());
+        assertEquals("1", result.next());
+        assertTrue(result.hasNext());
+        assertEquals("2", result.next());
+        assertTrue(result.hasNext());
+        assertEquals("3", result.next());
+
+        assertFalse(result.hasNext());
+    }
+
+
+    public void test_Ctors()
+    {
+        assertFalse(new PresentValues<>().hasNext());
+        assertFalse(new PresentValues<>(Absent.absent()).hasNext());
+        assertFalse(new PresentValues<>(Absent.absent(), Absent.absent()).hasNext());
+    }
+
+
+    @Test
+    public void test_whenOnePresentValue_ctors()
+    {
+        PresentValues<String> result = new PresentValues<>(new Present<>("hello"));
+
+        assertTrue(result.hasNext());
+        assertEquals("hello", result.next());
+        assertFalse(result.hasNext());
+    }
+
+
+    @Test
+    public void test_various_Ctors()
+    {
+        PresentValues<String> result = new PresentValues<>(new Present<>("1"),
+                ABSENT,
+                ABSENT,
+                new Present<>("2"),
+                new Present<>("3"),
+                ABSENT);
+
+        assertTrue(result.hasNext());
+        assertEquals("1", result.next());
+        assertTrue(result.hasNext());
+        assertEquals("2", result.next());
+        assertTrue(result.hasNext());
+        assertEquals("3", result.next());
+
+        assertFalse(result.hasNext());
+    }
+
+}

--- a/src/test/java/org/dmfs/jems/optional/adapters/CollapsedTest.java
+++ b/src/test/java/org/dmfs/jems/optional/adapters/CollapsedTest.java
@@ -17,8 +17,8 @@
 
 package org.dmfs.jems.optional.adapters;
 
-import org.dmfs.optional.Absent;
-import org.dmfs.optional.Present;
+import org.dmfs.jems.optional.elementary.Absent;
+import org.dmfs.jems.optional.elementary.Present;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.AbsentMatcher.isAbsent;

--- a/src/test/java/org/dmfs/jems/optional/adapters/FirstPresentTest.java
+++ b/src/test/java/org/dmfs/jems/optional/adapters/FirstPresentTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Present;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.dmfs.jems.optional.elementary.Absent.absent;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link FirstPresent}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class FirstPresentTest
+{
+
+    @Test
+    public void testVariousCases()
+    {
+        assertThat(new FirstPresent<>(new Seq<Optional<String>>()), is(AbsentMatcher.absent()));
+
+        assertThat(new FirstPresent<>(new Seq<Optional<String>>(absent())), is(AbsentMatcher.absent()));
+        assertThat(new FirstPresent<>(new Seq<Optional<String>>(absent(), absent())), is(AbsentMatcher.absent()));
+
+        assertThat(new FirstPresent<>(new Seq<>(new Present<>("1"))), is(present("1")));
+        assertThat(new FirstPresent<>(new Seq<>(absent(), new Present<>("1"))), is(present("1")));
+        assertThat(new FirstPresent<>(new Seq<>(new Present<>("1"), absent())), is(present("1")));
+
+        assertThat(new FirstPresent<>(new Seq<>(new Present<>("1"), new Present<>("2"))), is(present("1")));
+    }
+
+
+    @Test
+    public void testVariousVarargCases()
+    {
+        assertThat(new FirstPresent<>(), is(AbsentMatcher.absent()));
+
+        assertThat(new FirstPresent<>(absent()), is(AbsentMatcher.absent()));
+        assertThat(new FirstPresent<>(absent(), absent()), is(AbsentMatcher.absent()));
+
+        assertThat(new FirstPresent<>(new Present<>("1")), is(present("1")));
+        assertThat(new FirstPresent<>(absent(), new Present<>("1")), is(present("1")));
+        assertThat(new FirstPresent<>(new Present<>("1"), absent()), is(present("1")));
+
+        assertThat(new FirstPresent<>(new Present<>("1"), new Present<>("2")), is(present("1")));
+    }
+
+}

--- a/src/test/java/org/dmfs/jems/optional/adapters/FirstTest.java
+++ b/src/test/java/org/dmfs/jems/optional/adapters/FirstTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.iterators.Filter;
+import org.dmfs.jems.optional.adapters.First;
+import org.dmfs.jems.predicate.Predicate;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * Unit test for {@link First}.
+ *
+ * @author Marten Gajda
+ */
+public class FirstTest
+{
+    @Test
+    public void testFirst() throws Exception
+    {
+        assertThat(new First<>(EmptyIterable.<String>instance()), is(absent()));
+        assertThat(new First<>(new Seq<>("test")), is(present("test")));
+        assertThat(new First<>(new Seq<>("test", "test123")), is(present("test")));
+    }
+
+
+    @Test
+    public void testFilteredFirst() throws Exception
+    {
+        Filter<String> mockFilter = failingMock(Filter.class);
+        doReturn(false).when(mockFilter).iterate(anyString());
+        doReturn(true).when(mockFilter).iterate("test123");
+
+        assertThat(new First<>(EmptyIterable.<String>instance(), mockFilter), is(absent()));
+        assertThat(new First<>(new Seq<>("test"), mockFilter), is(absent()));
+        assertThat(new First<>(new Seq<>("test", "test123"), mockFilter), is(present("test123")));
+    }
+
+
+    @Test
+    public void testSievedFirst() throws Exception
+    {
+        Predicate<String> mockPredicate = failingMock(Predicate.class);
+        doReturn(false).when(mockPredicate).satisfiedBy(anyString());
+        doReturn(true).when(mockPredicate).satisfiedBy("test123");
+
+        assertThat(new First<>(EmptyIterable.<String>instance(), mockPredicate), is(absent()));
+        assertThat(new First<>(new Seq<>("test"), mockPredicate), is(absent()));
+        assertThat(new First<>(new Seq<>("test", "test123"), mockPredicate), is(present("test123")));
+    }
+}

--- a/src/test/java/org/dmfs/jems/optional/adapters/MapEntryTest.java
+++ b/src/test/java/org/dmfs/jems/optional/adapters/MapEntryTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * @author Marten Gajda
+ */
+public class MapEntryTest
+{
+    @Test
+    public void testIsPresent() throws Exception
+    {
+        Map<String, String> testMap = new HashMap<>();
+        testMap.put("key", "value");
+
+        assertThat(new MapEntry<>(testMap, "key"), is(present("value")));
+        assertThat(new MapEntry<>(testMap, "anotherKey"), is(absent()));
+    }
+}

--- a/src/test/java/org/dmfs/jems/optional/adapters/NextPresentTest.java
+++ b/src/test/java/org/dmfs/jems/optional/adapters/NextPresentTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Present;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.dmfs.jems.optional.elementary.Absent.absent;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link NextPresent}.
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class NextPresentTest
+{
+
+    @Test
+    public void testVariousCases()
+    {
+        assertThat(new NextPresent<>(new Seq<Optional<String>>()), is(AbsentMatcher.absent()));
+
+        assertThat(new NextPresent<>(new Seq<Optional<String>>(absent())), is(AbsentMatcher.absent()));
+        assertThat(new NextPresent<>(new Seq<Optional<String>>(absent(), absent())), is(AbsentMatcher.absent()));
+
+        assertThat(new NextPresent<>(new Seq<>(new Present<>("1"))), is(present("1")));
+        assertThat(new NextPresent<>(new Seq<>(absent(), new Present<>("1"))), is(present("1")));
+        assertThat(new NextPresent<>(new Seq<>(new Present<>("1"), absent())), is(present("1")));
+
+        assertThat(new NextPresent<>(new Seq<>(new Present<>("1"), new Present<>("2"))), is(present("1")));
+    }
+
+
+    @Test
+    public void testUsedIterator()
+    {
+        Iterator<Optional<String>> it1 = new Seq<>(new Present<>("1"), absent());
+        it1.next();
+        assertThat(new NextPresent<>(it1), is(AbsentMatcher.absent()));
+
+        Iterator<Optional<String>> it2 = new Seq<Optional<String>>(new Present<>("1"), new Present<>("2"));
+        it2.next();
+        assertThat(new NextPresent<>(it2), is(present("2")));
+
+        Iterator<Optional<String>> it3 = new Seq<Optional<String>>(new Present<>("1"), new Present<>("2"));
+        it3.next();
+        it3.next();
+        assertThat(new NextPresent<>(it3), is(AbsentMatcher.absent()));
+    }
+
+}

--- a/src/test/java/org/dmfs/jems/optional/adapters/NextTest.java
+++ b/src/test/java/org/dmfs/jems/optional/adapters/NextTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.dmfs.iterators.EmptyIterator;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.adapters.Next;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+/**
+ * Unit test for {@link Next}.
+ *
+ * @author Marten Gajda
+ */
+public class NextTest
+{
+    @Test
+    public void test_whenIteratorIsEmpty_resultShouldBeAbsent()
+    {
+        Optional<String> result = new Next<>(EmptyIterator.<String>instance());
+
+        assertFalse(result.isPresent());
+        try
+        {
+            result.value();
+            fail();
+        }
+        catch (NoSuchElementException e)
+        {
+            // pass
+        }
+    }
+
+
+    @Test
+    public void test_whenIteratorHasNextValue_resultShouldBeThat()
+    {
+        Optional<String> result = new Next<>(Arrays.asList("a", "b", "c").iterator());
+
+        assertTrue(result.isPresent());
+        assertEquals("a", result.value());
+    }
+
+
+    @Test
+    public void test_whenIteratorHasMovedAlready_resultShouldBeNext()
+    {
+        Iterator<String> iterator = Arrays.asList("a", "b", "c").iterator();
+        iterator.next();
+        Optional<String> result = new Next<>(iterator);
+
+        assertTrue(result.isPresent());
+        assertEquals("b", result.value());
+    }
+
+
+    @Test
+    public void test_whenIteratorReachedTheEnd_resultShouldBeAbsent()
+    {
+        Iterator<String> iterator = Arrays.asList("a", "b", "c").iterator();
+        iterator.next();
+        iterator.next();
+        iterator.next();
+        Optional<String> result = new Next<>(iterator);
+
+        assertFalse(result.isPresent());
+        try
+        {
+            result.value();
+            fail();
+        }
+        catch (NoSuchElementException e)
+        {
+            // pass
+        }
+    }
+
+}

--- a/src/test/java/org/dmfs/jems/optional/adapters/SinglePresentTest.java
+++ b/src/test/java/org/dmfs/jems/optional/adapters/SinglePresentTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.adapters;
+
+import org.dmfs.jems.single.elementary.ValueSingle;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link SinglePresent}
+ *
+ * @author Gabor Keszthelyi
+ */
+public final class SinglePresentTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new SinglePresent<>(new ValueSingle<>("a")), is(present("a")));
+    }
+
+}

--- a/src/test/java/org/dmfs/jems/optional/composite/ZippedTest.java
+++ b/src/test/java/org/dmfs/jems/optional/composite/ZippedTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.composite;
+
+import org.dmfs.jems.function.BiFunction;
+import org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher;
+import org.dmfs.jems.optional.elementary.Present;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.dmfs.jems.optional.elementary.Absent.absent;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+
+/**
+ * Test for {@link Zipped}.
+ *
+ * @author Marten Gajda
+ */
+public class ZippedTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new Zipped<>(new Present<>("val1"), new Present<>("val2"), stringBiFunction("val1", "val2", "result")), is(present("result")));
+        assertThat(new Zipped<>(new Present<>("val1"), absent(), failingMock(BiFunction.class)), is(AbsentMatcher.absent()));
+        assertThat(new Zipped<>(absent(), new Present<>("val2"), failingMock(BiFunction.class)), is(AbsentMatcher.absent()));
+        assertThat(new Zipped<>(absent(), absent(), failingMock(BiFunction.class)), is(AbsentMatcher.absent()));
+    }
+
+
+    private <Result> BiFunction<String, String, Result> stringBiFunction(String s1, String s2, Result result)
+    {
+        BiFunction<String, String, Result> mockFunction = mock(BiFunction.class);
+        doReturn(result).when(mockFunction).value(s1, s2);
+        return mockFunction;
+    }
+
+}

--- a/src/test/java/org/dmfs/jems/optional/decorators/DelegatingOptionalTest.java
+++ b/src/test/java/org/dmfs/jems/optional/decorators/DelegatingOptionalTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.decorators;
+
+import org.dmfs.jems.optional.elementary.Absent;
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.elementary.Present;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link DelegatingOptional}.
+ *
+ * @author Marten Gajda
+ */
+public class DelegatingOptionalTest
+{
+    @Test
+    public void testIsPresent() throws Exception
+    {
+        assertThat(new TestOptional<>(new Absent<String>()), is(absent()));
+        assertThat(new TestOptional<>(new Present<>("test")), is(present("test")));
+    }
+
+
+    private final class TestOptional<T> extends DelegatingOptional<T>
+    {
+        public TestOptional(Optional<T> delegate)
+        {
+            super(delegate);
+        }
+    }
+}

--- a/src/test/java/org/dmfs/jems/optional/decorators/SievedTest.java
+++ b/src/test/java/org/dmfs/jems/optional/decorators/SievedTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.decorators;
+
+import org.dmfs.jems.optional.elementary.Absent;
+import org.dmfs.jems.optional.elementary.Present;
+import org.dmfs.jems.predicate.elementary.Anything;
+import org.dmfs.jems.predicate.elementary.Nothing;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Sieved}.
+ *
+ * @author Marten Gajda
+ */
+public class SievedTest
+{
+    @Test
+    public void test() throws Exception
+    {
+        assertThat(new Sieved<>(new Anything<>(), new Present<>("test")), is(present("test")));
+        assertThat(new Sieved<>(new Nothing<>(), new Present<>("test")), is(absent()));
+        assertThat(new Sieved<>(new Anything<>(), new Absent<String>()), is(absent()));
+        assertThat(new Sieved<>(new Nothing<>(), new Absent<String>()), is(absent()));
+    }
+}

--- a/src/test/java/org/dmfs/jems/optional/elementary/AbsentTest.java
+++ b/src/test/java/org/dmfs/jems/optional/elementary/AbsentTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.elementary;
+
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Absent}.
+ *
+ * @author Marten Gajda
+ */
+public class AbsentTest
+{
+
+    @Test
+    public void test()
+    {
+        assertThat(new Absent<>(), is(absent()));
+        assertThat(Absent.absent(), is(absent()));
+    }
+}

--- a/src/test/java/org/dmfs/jems/optional/elementary/NullSafeTest.java
+++ b/src/test/java/org/dmfs/jems/optional/elementary/NullSafeTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.elementary;
+
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link NullSafe}.
+ *
+ * @author Marten Gajda
+ */
+public class NullSafeTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new NullSafe<>(null), is(absent()));
+        assertThat(new NullSafe<>("123"), is(present("123")));
+    }
+}

--- a/src/test/java/org/dmfs/jems/optional/elementary/PresentTest.java
+++ b/src/test/java/org/dmfs/jems/optional/elementary/PresentTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.optional.elementary;
+
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Present}.
+ *
+ * @author Marten Gajda
+ */
+public class PresentTest
+{
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNull()
+    {
+        new Present<>(null);
+    }
+
+
+    @Test
+    public void test()
+    {
+        assertThat(new Present<>("123"), is(present("123")));
+    }
+}


### PR DESCRIPTION
This introduces a new, simplified `Optional` type in the jems package which doesn't have the `value(T default)` method. This method caused a lot of duplicated code and can be replaced with a `Backed` single.
In addition it duplicates all (now deprecated) `Optional` implementations in the jems package.

Note, for compatibility, some of the implementations in the jems package still use the old `Optional`. This is subject to change.