### PR TITLE
Add PredicateMatcher, implements #166

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/predicate/PredicateMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/predicate/PredicateMatcher.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.predicate;
+
+import org.dmfs.jems.predicate.Predicate;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+
+/**
+ * A {@link Matcher} for {@link Predicate}s.
+ *
+ * @author Marten Gajda
+ */
+public final class PredicateMatcher<T> extends TypeSafeDiagnosingMatcher<Predicate<T>>
+{
+    private final T mTestee;
+
+
+    public static <T> Matcher<Predicate<T>> satisfiedBy(T testee)
+    {
+        return new PredicateMatcher<>(testee);
+    }
+
+
+    public PredicateMatcher(T mTestee)
+    {
+        this.mTestee = mTestee;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Predicate<T> item, Description mismatchDescription)
+    {
+        if (!item.satisfiedBy(mTestee))
+        {
+            mismatchDescription.appendText(String.format("was not satisfied by %s", mTestee));
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText(String.format("satisfied by %s", mTestee));
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/predicate/PredicateMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/predicate/PredicateMatcherTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.predicate;
+
+import org.dmfs.jems.predicate.Predicate;
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+
+/**
+ * Unit test for {@link PredicateMatcher}.
+ *
+ * @author Marten Gajda
+ */
+public class PredicateMatcherTest
+{
+
+    @Test
+    public void test()
+    {
+        Predicate<String> mockPredicate = mock(Predicate.class);
+        doReturn(true).when(mockPredicate).satisfiedBy("testee");
+        doReturn(false).when(mockPredicate).satisfiedBy("nontestee");
+
+        assertThat(satisfiedBy("testee").matches(mockPredicate), is(true));
+        assertThat(satisfiedBy("nontestee").matches(mockPredicate), is(false));
+    }
+
+
+    @Test
+    public void testDescribeMismatch()
+    {
+        Predicate<String> mockPredicate = mock(Predicate.class);
+        doReturn(false).when(mockPredicate).satisfiedBy(anyString());
+
+        Description description = new StringDescription();
+        satisfiedBy("testee").describeMismatch(mockPredicate, description);
+        assertThat(description.toString(), is("was not satisfied by testee"));
+    }
+
+
+    @Test
+    public void testDescribeTo()
+    {
+        Description description = new StringDescription();
+        satisfiedBy("testee").describeTo(description);
+        assertThat(description.toString(), is("satisfied by testee"));
+    }
+}

--- a/src/test/java/org/dmfs/jems/predicate/composite/AllOfTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/composite/AllOfTest.java
@@ -23,54 +23,50 @@ import org.dmfs.jems.predicate.Predicate;
 import org.dmfs.jems.predicate.elementary.Equals;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 
 /**
- * @author marten
+ * Test {@link AllOf}.
+ *
+ * @author Marten Gajda
  */
 public class AllOfTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
         // trivial predicate
-        assertThat(new AllOf<>().satisfiedBy(new Object()), is(true));
-        assertThat(new AllOf<>(EmptyIterable.<Predicate<Object>>instance()).satisfiedBy(new Object()), is(true));
+        assertThat(new AllOf<>(), is(satisfiedBy(new Object())));
+        assertThat(new AllOf<>(EmptyIterable.<Predicate<Object>>instance()), is(satisfiedBy(new Object())));
 
         // test matching predicates
-        assertThat(new AllOf<>(new Equals<>("test"), new Equals<>("test"), new Equals<>("test")).satisfiedBy("test"), is(true));
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("test"))).satisfiedBy("test"), is(true));
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("test"))).satisfiedBy("test"), is(true));
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("test"), new Equals<>("test"))).satisfiedBy("test"),
-                is(true));
+        assertThat(new AllOf<>(new Equals<>("test"), new Equals<>("test"), new Equals<>("test")), is(satisfiedBy("test")));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("test"))), is(satisfiedBy("test")));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("test"), new Equals<>("test"))), is(satisfiedBy("test")));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("test"), new Equals<>("test"), new Equals<>("test"))), is(satisfiedBy("test")));
 
         // mismatched predicates
 
         // one delegate
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("fail"))).satisfiedBy("test"), is(false));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("fail"))), is(not(satisfiedBy("test"))));
 
         // two delegates
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("fail"))).satisfiedBy("test"), is(false));
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("test"))).satisfiedBy("test"), is(false));
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("fail"))).satisfiedBy("test"), is(false));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("test"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("test"))), is(not(satisfiedBy("test"))));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
 
         // three delegates
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("test"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("test"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("test"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("test"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new AllOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(false));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("test"), new Equals<>("test"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("test"))), is(not(satisfiedBy("test"))));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("test"))), is(not(satisfiedBy("test"))));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("test"))), is(not(satisfiedBy("test"))));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
+        assertThat(new AllOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
     }
 
 }

--- a/src/test/java/org/dmfs/jems/predicate/composite/AnyOfTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/composite/AnyOfTest.java
@@ -19,60 +19,55 @@ package org.dmfs.jems.predicate.composite;
 
 import org.dmfs.iterables.EmptyIterable;
 import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.predicate.Predicate;
 import org.dmfs.jems.predicate.elementary.Equals;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 
 /**
- * @author marten
+ * Test {@link AnyOf}.
+ *
+ * @author Marten Gajda
  */
 public class AnyOfTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
         // trivial predicate
-        assertThat(new AnyOf<>().satisfiedBy(new Object()), is(true));
-        assertThat(new AnyOf<>(EmptyIterable.<Predicate<Object>>instance()).satisfiedBy(new Object()), is(true));
+        assertThat(new AnyOf<>(), is(satisfiedBy(new Object())));
+        assertThat(new AnyOf<>(EmptyIterable.instance()), is(satisfiedBy(new Object())));
 
         // test matching predicates
-        assertThat(new AnyOf<>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("fail")).satisfiedBy("test"), is(true));
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("test"))).satisfiedBy("test"), is(true));
+        assertThat(new AnyOf<>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("fail")), is(satisfiedBy("test")));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("test"))), is(satisfiedBy("test")));
 
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("test"))).satisfiedBy("test"), is(true));
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("fail"))).satisfiedBy("test"), is(true));
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("test"))).satisfiedBy("test"), is(true));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("test"), new Equals<>("test"))), is(satisfiedBy("test")));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("test"), new Equals<>("fail"))), is(satisfiedBy("test")));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("test"))), is(satisfiedBy("test")));
 
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("test"), new Equals<>("test"))).satisfiedBy("test"),
-                is(true));
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("test"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(true));
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("test"))).satisfiedBy("test"),
-                is(true));
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("test"))).satisfiedBy("test"),
-                is(true));
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(true));
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("test"))).satisfiedBy("test"),
-                is(true));
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(true));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("test"), new Equals<>("test"), new Equals<>("test"))), is(satisfiedBy("test")));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("test"), new Equals<>("test"), new Equals<>("fail"))), is(satisfiedBy("test")));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("test"))), is(satisfiedBy("test")));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("test"))), is(satisfiedBy("test")));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("fail"))), is(satisfiedBy("test")));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("test"))), is(satisfiedBy("test")));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("fail"))), is(satisfiedBy("test")));
 
         // mismatched predicates
 
         // one delegate
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("fail"))).satisfiedBy("test"), is(false));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("fail"))), is(not(satisfiedBy("test"))));
 
         // two delegates
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("fail"))).satisfiedBy("test"), is(false));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
 
         // three delegates
-        assertThat(new AnyOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(false));
+        assertThat(new AnyOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
     }
 
 }

--- a/src/test/java/org/dmfs/jems/predicate/composite/LeftWithTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/composite/LeftWithTest.java
@@ -21,22 +21,26 @@ import org.dmfs.jems.pair.elementary.ValuePair;
 import org.dmfs.jems.predicate.elementary.SameAs;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 
 /**
+ * Test {@link LeftWith}.
+ *
  * @author Marten Gajda
  */
 public class LeftWithTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
         Object leftDummy = dummy(Object.class);
-        assertThat(new LeftWith<>(new SameAs<>(leftDummy)).satisfiedBy(new ValuePair<>(leftDummy, dummy(Object.class))), is(true));
-        assertThat(new LeftWith<>(new SameAs<>(leftDummy)).satisfiedBy(new ValuePair<>(dummy(Object.class), dummy(Object.class))), is(false));
+        assertThat(new LeftWith<>(new SameAs<>(leftDummy)), is(satisfiedBy(new ValuePair<>(leftDummy, dummy(Object.class)))));
+        assertThat(new LeftWith<>(new SameAs<>(leftDummy)), is(not(satisfiedBy(new ValuePair<>(dummy(Object.class), dummy(Object.class))))));
     }
 
 }

--- a/src/test/java/org/dmfs/jems/predicate/composite/NoneOfTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/composite/NoneOfTest.java
@@ -19,16 +19,19 @@ package org.dmfs.jems.predicate.composite;
 
 import org.dmfs.iterables.EmptyIterable;
 import org.dmfs.iterables.elementary.Seq;
-import org.dmfs.jems.predicate.Predicate;
 import org.dmfs.jems.predicate.elementary.Equals;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 
 /**
- * @author marten
+ * Test {@link NoneOf}.
+ *
+ * @author Marten Gajda
  */
 public class NoneOfTest
 {
@@ -37,42 +40,34 @@ public class NoneOfTest
     public void testSatisfiedBy() throws Exception
     {
         // trivial predicate
-        assertThat(new NoneOf<>().satisfiedBy(new Object()), is(false));
-        assertThat(new NoneOf<>(EmptyIterable.<Predicate<Object>>instance()).satisfiedBy(new Object()), is(false));
+        assertThat(new NoneOf<>(), is(not(satisfiedBy(new Object()))));
+        assertThat(new NoneOf<>(EmptyIterable.instance()), is(not(satisfiedBy(new Object()))));
 
         // test matching predicates
-        assertThat(new NoneOf<>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("fail")).satisfiedBy("test"), is(true));
+        assertThat(new NoneOf<>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("fail")), is(satisfiedBy("test")));
 
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("fail"))).satisfiedBy("test"), is(true));
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("fail"))).satisfiedBy("test"), is(true));
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(true));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("fail"))), is(satisfiedBy("test")));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("fail"))), is(satisfiedBy("test")));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("fail"))), is(satisfiedBy("test")));
 
         // mismatched predicates
 
         // one delegate
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("test"))).satisfiedBy("test"), is(false));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("test"))), is(not(satisfiedBy("test"))));
 
         // two delegates
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("test"))).satisfiedBy("test"), is(false));
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("fail"))).satisfiedBy("test"), is(false));
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("test"))).satisfiedBy("test"), is(false));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("test"), new Equals<>("test"))), is(not(satisfiedBy("test"))));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("test"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("test"))), is(not(satisfiedBy("test"))));
 
         // three delegates
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("test"), new Equals<>("test"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("test"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("test"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("test"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("test"))).satisfiedBy("test"),
-                is(false));
-        assertThat(new NoneOf<>(new Seq<Predicate<String>>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("fail"))).satisfiedBy("test"),
-                is(false));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("test"), new Equals<>("test"), new Equals<>("test"))), is(not(satisfiedBy("test"))));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("test"), new Equals<>("test"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("test"))), is(not(satisfiedBy("test"))));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("test"))), is(not(satisfiedBy("test"))));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("test"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("fail"), new Equals<>("fail"), new Equals<>("test"))), is(not(satisfiedBy("test"))));
+        assertThat(new NoneOf<>(new Seq<>(new Equals<>("test"), new Equals<>("fail"), new Equals<>("fail"))), is(not(satisfiedBy("test"))));
     }
 
 }

--- a/src/test/java/org/dmfs/jems/predicate/composite/NotTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/composite/NotTest.java
@@ -3,25 +3,29 @@ package org.dmfs.jems.predicate.composite;
 import org.dmfs.jems.predicate.Predicate;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doReturn;
 
 
 /**
- * @author marten
+ * Test {@link Not}.
+ *
+ * @author Marten Gajda
  */
 public class NotTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
         Predicate<String> mockPredicate = failingMock(Predicate.class);
         doReturn(true).when(mockPredicate).satisfiedBy("match");
         doReturn(false).when(mockPredicate).satisfiedBy("mismatch");
 
-        assertThat(new Not<>(mockPredicate).satisfiedBy("match"), is(false));
-        assertThat(new Not<>(mockPredicate).satisfiedBy("mismatch"), is(true));
+        assertThat(new Not<>(mockPredicate), is(not(satisfiedBy("match"))));
+        assertThat(new Not<>(mockPredicate), is(satisfiedBy("mismatch")));
     }
 }

--- a/src/test/java/org/dmfs/jems/predicate/composite/PairWithTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/composite/PairWithTest.java
@@ -21,25 +21,29 @@ import org.dmfs.jems.pair.elementary.ValuePair;
 import org.dmfs.jems.predicate.elementary.SameAs;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 
 /**
+ * Test {@link PairWith}.
+ *
  * @author Marten Gajda
  */
 public class PairWithTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
         Object leftDummy = dummy(Object.class);
         Object rightDummy = dummy(Object.class);
-        assertThat(new PairWith<>(new SameAs<>(leftDummy), new SameAs<>(rightDummy)).satisfiedBy(new ValuePair<>(leftDummy, rightDummy)), is(true));
-        assertThat(new PairWith<>(new SameAs<>(leftDummy), new SameAs<>(rightDummy)).satisfiedBy(new ValuePair<>(leftDummy, dummy(Object.class))), is(false));
-        assertThat(new PairWith<>(new SameAs<>(leftDummy), new SameAs<>(rightDummy)).satisfiedBy(new ValuePair<>(dummy(Object.class), rightDummy)), is(false));
-        assertThat(new PairWith<>(new SameAs<>(leftDummy), new SameAs<>(rightDummy)).satisfiedBy(new ValuePair<>(dummy(Object.class), dummy(Object.class))),
-                is(false));
+        assertThat(new PairWith<>(new SameAs<>(leftDummy), new SameAs<>(rightDummy)), is(satisfiedBy(new ValuePair<>(leftDummy, rightDummy))));
+        assertThat(new PairWith<>(new SameAs<>(leftDummy), new SameAs<>(rightDummy)), is(not(satisfiedBy(new ValuePair<>(leftDummy, dummy(Object.class))))));
+        assertThat(new PairWith<>(new SameAs<>(leftDummy), new SameAs<>(rightDummy)), is(not(satisfiedBy(new ValuePair<>(dummy(Object.class), rightDummy)))));
+        assertThat(new PairWith<>(new SameAs<>(leftDummy), new SameAs<>(rightDummy)),
+                is(not(satisfiedBy(new ValuePair<>(dummy(Object.class), dummy(Object.class))))));
     }
 }

--- a/src/test/java/org/dmfs/jems/predicate/composite/RightWithTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/composite/RightWithTest.java
@@ -21,21 +21,25 @@ import org.dmfs.jems.pair.elementary.ValuePair;
 import org.dmfs.jems.predicate.elementary.SameAs;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 
 /**
+ * Test {@link RightWith}.
+ *
  * @author Marten Gajda
  */
 public class RightWithTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
         Object rightDummy = dummy(Object.class);
-        assertThat(new RightWith<>(new SameAs<>(rightDummy)).satisfiedBy(new ValuePair<>(dummy(Object.class), rightDummy)), is(true));
-        assertThat(new RightWith<>(new SameAs<>(rightDummy)).satisfiedBy(new ValuePair<>(dummy(Object.class), dummy(Object.class))), is(false));
+        assertThat(new RightWith<>(new SameAs<>(rightDummy)), is(satisfiedBy(new ValuePair<>(dummy(Object.class), rightDummy))));
+        assertThat(new RightWith<>(new SameAs<>(rightDummy)), is(not(satisfiedBy(new ValuePair<>(dummy(Object.class), dummy(Object.class))))));
     }
 }

--- a/src/test/java/org/dmfs/jems/predicate/composite/SingleWithTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/composite/SingleWithTest.java
@@ -21,22 +21,26 @@ import org.dmfs.jems.predicate.elementary.SameAs;
 import org.dmfs.jems.single.elementary.ValueSingle;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 
 /**
+ * Test {@link SingleWith}.
+ *
  * @author Marten Gajda
  */
 public class SingleWithTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
         Object dummy = dummy(Object.class);
-        assertThat(new SingleWith<>(new SameAs<>(dummy)).satisfiedBy(new ValueSingle<>(dummy)), is(true));
-        assertThat(new SingleWith<>(new SameAs<>(dummy)).satisfiedBy(new ValueSingle<>(dummy(Object.class))), is(false));
+        assertThat(new SingleWith<>(new SameAs<>(dummy)), is(satisfiedBy(new ValueSingle<>(dummy))));
+        assertThat(new SingleWith<>(new SameAs<>(dummy)), is(not(satisfiedBy(new ValueSingle<>(dummy(Object.class))))));
     }
 
 }

--- a/src/test/java/org/dmfs/jems/predicate/elementary/AnythingTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/elementary/AnythingTest.java
@@ -19,22 +19,25 @@ package org.dmfs.jems.predicate.elementary;
 
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 
 /**
- * @author marten
+ * Test {@link Anything}.
+ *
+ * @author Marten Gajda
  */
 public class AnythingTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
-        assertThat(new Anything<>().satisfiedBy("test"), is(true));
-        assertThat(new Anything<>().satisfiedBy(1), is(true));
-        assertThat(new Anything<>().satisfiedBy(true), is(true));
-        assertThat(new Anything<>().satisfiedBy(new Object()), is(true));
+        assertThat(new Anything<>(), is(satisfiedBy("test")));
+        assertThat(new Anything<>(), is(satisfiedBy(1)));
+        assertThat(new Anything<>(), is(satisfiedBy(true)));
+        assertThat(new Anything<>(), is(satisfiedBy(new Object())));
     }
 
 }

--- a/src/test/java/org/dmfs/jems/predicate/elementary/DelegatingPredicateTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/elementary/DelegatingPredicateTest.java
@@ -20,29 +20,33 @@ package org.dmfs.jems.predicate.elementary;
 import org.dmfs.jems.predicate.Predicate;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.dummy;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 
 
 /**
- * @author marten
+ * Test {@link DelegatingPredicate}.
+ *
+ * @author Marten Gajda
  */
 public class DelegatingPredicateTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
         Object testDummy = dummy(Object.class);
         Predicate<Object> mockPredicate = failingMock(Predicate.class);
         doReturn(false).when(mockPredicate).satisfiedBy(any());
         doReturn(true).when(mockPredicate).satisfiedBy(testDummy);
 
-        assertThat(new TestPredicate<>(mockPredicate).satisfiedBy(new Object()), is(false));
-        assertThat(new TestPredicate<>(mockPredicate).satisfiedBy(testDummy), is(true));
+        assertThat(new TestPredicate<>(mockPredicate), is(not(satisfiedBy(new Object()))));
+        assertThat(new TestPredicate<>(mockPredicate), is(satisfiedBy(testDummy)));
     }
 
 

--- a/src/test/java/org/dmfs/jems/predicate/elementary/EqualsTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/elementary/EqualsTest.java
@@ -19,20 +19,24 @@ package org.dmfs.jems.predicate.elementary;
 
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 
 /**
- * @author marten
+ * Test {@link Equals}.
+ *
+ * @author Marten Gajda
  */
 public class EqualsTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
-        assertThat(new Equals<>(new String("test")).satisfiedBy(new String("test")), is(true));
-        assertThat(new Equals<>("test").satisfiedBy("fail"), is(false));
+        assertThat(new Equals<>(new String("test")), is(satisfiedBy(new String("test"))));
+        assertThat(new Equals<>("test"), is(not(satisfiedBy("fail"))));
     }
 
 }

--- a/src/test/java/org/dmfs/jems/predicate/elementary/NothingTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/elementary/NothingTest.java
@@ -19,22 +19,26 @@ package org.dmfs.jems.predicate.elementary;
 
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 
 /**
- * @author marten
+ * Test {@link Nothing}.
+ *
+ * @author Marten Gajda
  */
 public class NothingTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
-        assertThat(new Nothing<>().satisfiedBy("test"), is(false));
-        assertThat(new Nothing<>().satisfiedBy(1), is(false));
-        assertThat(new Nothing<>().satisfiedBy(true), is(false));
-        assertThat(new Nothing<>().satisfiedBy(new Object()), is(false));
+        assertThat(new Nothing<>(), is(not(satisfiedBy("test"))));
+        assertThat(new Nothing<>(), is(not(satisfiedBy(1))));
+        assertThat(new Nothing<>(), is(not(satisfiedBy(true))));
+        assertThat(new Nothing<>(), is(not(satisfiedBy(new Object()))));
     }
 
 }

--- a/src/test/java/org/dmfs/jems/predicate/elementary/SameAsTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/elementary/SameAsTest.java
@@ -19,21 +19,25 @@ package org.dmfs.jems.predicate.elementary;
 
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.predicate.PredicateMatcher.satisfiedBy;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 
 /**
- * @author marten
+ * Test {@link SameAs}.
+ *
+ * @author Marten Gajda
  */
 public class SameAsTest
 {
     @Test
-    public void testSatisfiedBy() throws Exception
+    public void testSatisfiedBy()
     {
         Object mockObject = new Object();
-        assertThat(new SameAs<>(mockObject).satisfiedBy(mockObject), is(true));
-        assertThat(new SameAs<>(new Integer(1)).satisfiedBy(new Integer(1)), is(false));
+        assertThat(new SameAs<>(mockObject), is(satisfiedBy(mockObject)));
+        assertThat(new SameAs<>(new Integer(1)), is(not(satisfiedBy(new Integer(1)))));
     }
 
 }


### PR DESCRIPTION
This commit adds a PredicateMatcher which allows `Predicate`s to be tested like

    assertThat(predicate, is(satisfied(expectation)));