### PR TITLE
Matchers for Matchers, implements #174

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/matcher/DescriptionMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/matcher/DescriptionMatcher.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.matcher;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+
+/**
+ * A {@link Matcher} to test the description of another {@link Matcher}.
+ *
+ * @author Marten Gajda
+ */
+public final class DescriptionMatcher<V, T extends Matcher<V>> extends TypeSafeDiagnosingMatcher<T>
+{
+    private final Matcher<? extends CharSequence> mDescriptionMatcher;
+
+
+    public DescriptionMatcher(Matcher<? extends CharSequence> descriptionMatcher)
+    {
+        mDescriptionMatcher = descriptionMatcher;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(T item, Description mismatchDescription)
+    {
+        Description description = new StringDescription();
+        item.describeTo(description);
+        if (!mDescriptionMatcher.matches(description.toString()))
+        {
+            mismatchDescription.appendText("description ");
+            mDescriptionMatcher.describeMismatch(description.toString(), mismatchDescription);
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("description ");
+        mDescriptionMatcher.describeTo(description);
+    }
+}

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/matcher/MatchMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/matcher/MatchMatcher.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.matcher;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+
+/**
+ * A {@link Matcher} to check if another Matcher matches a specific value.
+ *
+ * @author Marten Gajda
+ */
+public final class MatchMatcher<V, T extends Matcher<V>> extends TypeSafeDiagnosingMatcher<T>
+{
+    private final V mMatchingValue;
+
+
+    public MatchMatcher(V matchingValue)
+    {
+        mMatchingValue = matchingValue;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(T item, Description mismatchDescription)
+    {
+        if (!item.matches(mMatchingValue))
+        {
+            mismatchDescription.appendText(String.format("didn't match \"%s\"", mMatchingValue.toString()));
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText(String.format("matches \"%s\"", mMatchingValue.toString()));
+    }
+}

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/matcher/MatcherMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/matcher/MatcherMatcher.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.matcher;
+
+import org.hamcrest.Matcher;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.any;
+
+
+/**
+ * Collection of static matcher factories to test {@link Matcher}s.
+ *
+ * @author Marten Gajda
+ */
+public final class MatcherMatcher
+{
+    public static <Value, MatcherType extends Matcher<Value>> Matcher<MatcherType> matches(Value value)
+    {
+        return new MatchMatcher<>(value);
+    }
+
+
+    public static <V, T extends Matcher<V>> Matcher<T> describesAs(String description)
+    {
+        return describesAs(is(description));
+    }
+
+
+    public static <V, T extends Matcher<V>> Matcher<T> describesAs(Matcher<? extends CharSequence> descriptionMatcher)
+    {
+        return new DescriptionMatcher<>(descriptionMatcher);
+    }
+
+
+    public static <V, T extends Matcher<V>> Matcher<T> mismatches(V value)
+    {
+        return new MismatchMatcher<>(value, any(String.class));
+    }
+
+
+    public static <V, T extends Matcher<V>> Matcher<T> mismatches(V value, String mismatchDescription)
+    {
+        return new MismatchMatcher<>(value, is(mismatchDescription));
+    }
+
+
+    public static <V, T extends Matcher<V>> Matcher<T> mismatches(V value, Matcher<? extends CharSequence> mismatchDescriptionMatcher)
+    {
+        return new MismatchMatcher<>(value, mismatchDescriptionMatcher);
+    }
+
+}

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/matcher/MismatchMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/matcher/MismatchMatcher.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.matcher;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+
+/**
+ * A {@link Matcher} to check if another {@link Matcher} mismatches a specific value with a specific description.
+ *
+ * @author Marten Gajda
+ */
+public final class MismatchMatcher<V, T extends Matcher<V>> extends TypeSafeDiagnosingMatcher<T>
+{
+    private final V mMismatchItem;
+    private final Matcher<? extends CharSequence> mDescriptionMatcher;
+
+
+    public MismatchMatcher(V mismatchItem, Matcher<? extends CharSequence> descriptionMatcher)
+    {
+        mMismatchItem = mismatchItem;
+        mDescriptionMatcher = descriptionMatcher;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(T item, Description mismatchDescription)
+    {
+        if (item.matches(mMismatchItem))
+        {
+            mismatchDescription.appendText(String.format("did match \"%s\"", mMismatchItem.toString()));
+            return false;
+        }
+        Description description = new StringDescription();
+        item.describeMismatch(mMismatchItem, description);
+        if (!mDescriptionMatcher.matches(description.toString()))
+        {
+            mismatchDescription.appendText("description ");
+            mDescriptionMatcher.describeMismatch(description.toString(), mismatchDescription);
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("mismatch description ");
+        mDescriptionMatcher.describeTo(description);
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/matcher/DescriptionMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/matcher/DescriptionMatcherTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.matcher;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+
+
+/**
+ * Unit test for {@link DescriptionMatcher}.
+ *
+ * @author Marten Gajda
+ */
+public class DescriptionMatcherTest
+{
+
+    @Test
+    public void testMatches() throws Exception
+    {
+        Matcher mockMatcher = failingMock(Matcher.class);
+        doAnswer(invocation -> {
+            Description description = invocation.getArgument(0);
+            description.appendText("description");
+            return null;
+        }).when(mockMatcher).describeTo(any(Description.class));
+        assertThat(new DescriptionMatcher<>(is("description")), matches(mockMatcher));
+        assertThat(describesAs(is("description")), matches(mockMatcher));
+    }
+
+
+    @Test
+    public void testMismatches() throws Exception
+    {
+        Matcher mockMatcher = failingMock(Matcher.class);
+        doAnswer(invocation -> {
+            Description description = invocation.getArgument(0);
+            description.appendText("text");
+            return null;
+        }).when(mockMatcher).describeTo(any(Description.class));
+        assertThat(new DescriptionMatcher<>(is("description")), mismatches(mockMatcher, "description was \"text\""));
+        assertThat(describesAs(is("description")), mismatches(mockMatcher, "description was \"text\""));
+    }
+
+
+    @Test
+    public void testDescribeTo() throws Exception
+    {
+        Description description = new StringDescription();
+        new DescriptionMatcher<>(is("text")).describeTo(description);
+
+        assertThat(description.toString(), is("description is \"text\""));
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/matcher/MatchMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/matcher/MatchMatcherTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.matcher;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * Unit test for {@link MatchMatcher}.
+ *
+ * @author Marten Gajda
+ */
+public class MatchMatcherTest
+{
+
+    @Test
+    public void testMatches() throws Exception
+    {
+        Object dummy = new Object();
+        Matcher mockMatcher = failingMock(Matcher.class);
+        doReturn(true).when(mockMatcher).matches(dummy);
+
+        assertThat(new MatchMatcher<>(dummy).matches(mockMatcher), is(true));
+        assertThat(matches(dummy).matches(mockMatcher), is(true));
+    }
+
+
+    @Test
+    public void testMismatches() throws Exception
+    {
+        Object dummy = new Object();
+        Matcher mockMatcher = failingMock(Matcher.class);
+        doReturn(false).when(mockMatcher).matches(dummy);
+
+        assertThat(new MatchMatcher<>(dummy).matches(mockMatcher), is(false));
+        assertThat(matches(dummy).matches(mockMatcher), is(false));
+    }
+
+
+    @Test
+    public void testMismatchDescription() throws Exception
+    {
+        String dummy = "dummy";
+        Matcher mockMatcher = failingMock(Matcher.class);
+        doReturn(false).when(mockMatcher).matches(dummy);
+
+        Description description = new StringDescription();
+        new MatchMatcher<>(dummy).describeMismatch(mockMatcher, description);
+
+        assertThat(description.toString(), is("didn't match \"dummy\""));
+    }
+
+
+    @Test
+    public void testDescribeTo() throws Exception
+    {
+        assertThat(new MatchMatcher<>("test"), describesAs("matches \"test\""));
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/matcher/MismatchMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/matcher/MismatchMatcherTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.matcher;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+
+
+/**
+ * Unit test for {@link MismatchMatcher}.
+ *
+ * @author Marten Gajda
+ */
+public class MismatchMatcherTest
+{
+
+    @Test
+    public void testMatches() throws Exception
+    {
+        String dummy = "dummy";
+        Matcher mockMatcher = failingMock(Matcher.class);
+        doReturn(false).when(mockMatcher).matches(dummy);
+        doAnswer(invocation -> {
+            Description description = invocation.getArgument(1);
+            description.appendText("mismatch description");
+            return null;
+        }).when(mockMatcher).describeMismatch(same(dummy), any(Description.class));
+
+        assertThat(new MismatchMatcher<>(dummy, is("mismatch description")), matches(mockMatcher));
+        assertThat(mismatches(dummy), matches(mockMatcher));
+        assertThat(mismatches(dummy, "mismatch description"), matches(mockMatcher));
+        assertThat(mismatches(dummy, is("mismatch description")), matches(mockMatcher));
+    }
+
+
+    @Test
+    public void testMismatches() throws Exception
+    {
+        String dummy = "dummy";
+        Matcher mockMatcher = failingMock(Matcher.class);
+        doReturn(true).when(mockMatcher).matches(dummy);
+
+        assertThat(new MismatchMatcher<>(dummy, is("mismatch description")).matches(mockMatcher), is(false));
+        assertThat(mismatches(dummy).matches(mockMatcher), is(false));
+        assertThat(mismatches(dummy, "mismatch description").matches(mockMatcher), is(false));
+        assertThat(mismatches(dummy, is("mismatch description")).matches(mockMatcher), is(false));
+    }
+
+
+    @Test
+    public void testMismatchDescription1() throws Exception
+    {
+        String dummy = "dummy";
+        Matcher mockMatcher = failingMock(Matcher.class);
+        doReturn(true).when(mockMatcher).matches(dummy);
+
+        Description description = new StringDescription();
+        new MismatchMatcher<>(dummy, is("description")).describeMismatch(mockMatcher, description);
+
+        assertThat(description.toString(), is("did match \"dummy\""));
+    }
+
+
+    @Test
+    public void testMismatchDescription2() throws Exception
+    {
+        String dummy = "dummy";
+        Matcher mockMatcher = failingMock(Matcher.class);
+        doReturn(false).when(mockMatcher).matches(dummy);
+        doAnswer(invocation -> {
+            Description description = invocation.getArgument(1);
+            description.appendText("text");
+            return null;
+        }).when(mockMatcher).describeMismatch(same(dummy), any(Description.class));
+
+        Description description = new StringDescription();
+        new MismatchMatcher<>(dummy, is("description")).describeMismatch(mockMatcher, description);
+
+        assertThat(description.toString(), is("description was \"text\""));
+    }
+
+
+    @Test
+    public void testDescribeTo() throws Exception
+    {
+        assertThat(new MismatchMatcher<>("test", is("description")), describesAs("mismatch description is \"description\""));
+    }
+}


### PR DESCRIPTION
This adds Hamcrest Matchers to test Hamcrest Matchers so they can be tested more easily and declaratively.