### PR TITLE
Provide initial Sequence value via Generator. Implements #179

### DIFF
--- a/src/main/java/org/dmfs/jems/generatable/elementary/Sequence.java
+++ b/src/main/java/org/dmfs/jems/generatable/elementary/Sequence.java
@@ -29,20 +29,26 @@ import org.dmfs.jems.generator.Generator;
  */
 public final class Sequence<T> implements Generatable<T>
 {
-    private T mFirst;
+    private final Generator<T> mInitialValues;
     private final Function<T, T> mFunction;
 
 
-    public Sequence(T first, Function<T, T> function)
+    public Sequence(Generator<T> initialValues, Function<T, T> function)
     {
-        mFirst = first;
+        mInitialValues = initialValues;
         mFunction = function;
+    }
+
+
+    public Sequence(T initialValue, Function<T, T> function)
+    {
+        this(() -> initialValue, function);
     }
 
 
     @Override
     public Generator<T> generator()
     {
-        return new org.dmfs.jems.generator.elementary.Sequence<>(mFirst, mFunction);
+        return new org.dmfs.jems.generator.elementary.Sequence<>(mInitialValues.next(), mFunction);
     }
 }

--- a/src/main/java/org/dmfs/jems/generator/Generator.java
+++ b/src/main/java/org/dmfs/jems/generator/Generator.java
@@ -17,12 +17,18 @@
 
 package org.dmfs.jems.generator;
 
+import org.dmfs.jems.single.Single;
+
 import java.util.Iterator;
 
 
 /**
  * A Generator is able to generate an infinite sequence of values. It's similar to {@link Iterator} with the difference that a generator always has a next
  * element, hence there is no {@code hasNext()} method.
+ * <p>
+ * A Generator also serves as an equivalent to {@link Single} for mutable values. A {@link Single} should not be used with mutable values because mutation of
+ * the value would affect all other uses of the {@link Single} because other callers might receive the mutated value. A {@link Generator} on the other hand is
+ * expected to return (generate) a new instance on each call if the results are mutable.
  *
  * @author Marten Gajda
  */

--- a/src/test/java/org/dmfs/jems/generatable/elementary/SequenceTest.java
+++ b/src/test/java/org/dmfs/jems/generatable/elementary/SequenceTest.java
@@ -17,6 +17,10 @@
 
 package org.dmfs.jems.generatable.elementary;
 
+import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.generatable.Generatable;
+import org.dmfs.jems.iterable.decorators.Mapped;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.GeneratableMatcher.startsWith;
@@ -36,5 +40,10 @@ public final class SequenceTest
         assertThat(new Sequence<>(1, a -> a + 1), startsWith(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
         assertThat(new Sequence<>(1, a -> a), startsWith(1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
         assertThat(new Sequence<>("a", a -> a + "a"), startsWith("a", "aa", "aaa", "aaaa"));
+
+        Generatable<StringBuilder> testee = new Sequence<StringBuilder>(StringBuilder::new, v -> v.append("a"));
+        // the Generatable should always start with an empty StringBuilder and the sequence should always look the same
+        assertThat(testee, startsWith(new Mapped<>(Matchers::hasToString, new Seq<>("", "a", "aa", "aaa", "aaaa", "aaaaa"))));
+        assertThat(testee, startsWith(new Mapped<>(Matchers::hasToString, new Seq<>("", "a", "aa", "aaa", "aaaa", "aaaaa"))));
     }
 }


### PR DESCRIPTION
In order to allow generating sequences of mutable values, the initial value can now be provided by a `Generator` istelf to ensure the `Sequence` always starts with a fresh inital value.