### PR TITLE
Simplify Frozen Single, implements #176

### DIFF
--- a/src/main/java/org/dmfs/jems/single/elementary/Frozen.java
+++ b/src/main/java/org/dmfs/jems/single/elementary/Frozen.java
@@ -23,28 +23,26 @@ import org.dmfs.jems.single.Single;
 /**
  * {@link Single} decorator that queries the delegate only once and returns the same value instance ever after.
  *
- * @author Gabor Keszthelyi
+ * @author Marten Gajda
  */
 public final class Frozen<T> implements Single<T>
 {
-    private final Single<T> mDelegate;
-
-    private T mFrozenValue;
+    private Single<T> mDelegate;
 
 
     public Frozen(Single<T> delegate)
     {
-        mDelegate = delegate;
+        mDelegate = () -> {
+            T result = delegate.value();
+            mDelegate = () -> result;
+            return result;
+        };
     }
 
 
     @Override
     public T value()
     {
-        if (mFrozenValue == null)
-        {
-            mFrozenValue = mDelegate.value();
-        }
-        return mFrozenValue;
+        return mDelegate.value();
     }
 }

--- a/src/test/java/org/dmfs/jems/single/elementary/FrozenTest.java
+++ b/src/test/java/org/dmfs/jems/single/elementary/FrozenTest.java
@@ -20,6 +20,7 @@ package org.dmfs.jems.single.elementary;
 import org.dmfs.jems.single.Single;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.SingleMatcher.hasValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
@@ -36,11 +37,11 @@ public final class FrozenTest
     {
         Object firstValue = new Object();
 
-        Single<Object> frozen = new Frozen(new ChangingValueSingle(firstValue));
+        Single<Object> frozen = new Frozen<>(new ChangingValueSingle(firstValue));
 
-        assertThat(frozen.value(), sameInstance(firstValue));
-        assertThat(frozen.value(), sameInstance(firstValue));
-        assertThat(frozen.value(), sameInstance(firstValue));
+        assertThat(frozen, hasValue(sameInstance(firstValue)));
+        assertThat(frozen, hasValue(sameInstance(firstValue)));
+        assertThat(frozen, hasValue(sameInstance(firstValue)));
     }
 
 


### PR DESCRIPTION
`Frozen` is meant to be used to reduce the overhead of potentially expensive delegates. This change allows `Frozen` to release the delegate value once the value has been retrieved.