### PR TITLE
Implement Chunked Iterable, implements #183

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcher.java
@@ -36,34 +36,34 @@ import java.util.NoSuchElementException;
  *
  * @author Marten Gajda
  */
-public final class IteratorMatcher<T> extends TypeSafeDiagnosingMatcher<Generator<? extends Iterator<T>>>
+public final class IteratorMatcher<T> extends TypeSafeDiagnosingMatcher<Generator<? extends Iterator<? extends T>>>
 {
     public static final int HAS_NEXT_TEST_COUNT = 100;
     public static final int EXCEPTION_TEST_COUNT = 100;
     private final Iterable<Matcher<T>> mElementMatchers;
 
 
-    public static <T> Matcher<Generator<? extends Iterator<T>>> emptyIterator()
+    public static <T> Matcher<Generator<? extends Iterator<? extends T>>> emptyIterator()
     {
         return new IteratorMatcher<>(new EmptyIterable<>());
     }
 
 
     @SafeVarargs
-    public static <T> Matcher<Generator<? extends Iterator<T>>> iteratorOf(T... elements)
+    public static <T> Matcher<Generator<? extends Iterator<? extends T>>> iteratorOf(T... elements)
     {
         return new IteratorMatcher<>(new Mapped<>(Matchers::equalTo, new Seq<>(elements)));
     }
 
 
-    public static <T> Matcher<Generator<? extends Iterator<T>>> iteratorOf(Iterable<Matcher<T>> elementMatchers)
+    public static <T> Matcher<Generator<? extends Iterator<? extends T>>> iteratorOf(Iterable<Matcher<T>> elementMatchers)
     {
         return new IteratorMatcher<>(elementMatchers);
     }
 
 
     @SafeVarargs
-    public static <T> Matcher<Generator<? extends Iterator<T>>> iteratorOf(Matcher<T>... elementMatchers)
+    public static <T> Matcher<Generator<? extends Iterator<? extends T>>> iteratorOf(Matcher<T>... elementMatchers)
     {
         return new IteratorMatcher<>(new Seq<>(elementMatchers));
     }
@@ -76,10 +76,10 @@ public final class IteratorMatcher<T> extends TypeSafeDiagnosingMatcher<Generato
 
 
     @Override
-    protected boolean matchesSafely(Generator<? extends Iterator<T>> item, Description mismatchDescription)
+    protected boolean matchesSafely(Generator<? extends Iterator<? extends T>> item, Description mismatchDescription)
     {
         Iterator<Matcher<T>> matcherIterator = mElementMatchers.iterator();
-        Iterator<T> testee = item.next();
+        Iterator<? extends T> testee = item.next();
         int index = 0;
         while (testee.hasNext() && matcherIterator.hasNext())
         {

--- a/src/main/java/org/dmfs/jems/iterable/decorators/Chunked.java
+++ b/src/main/java/org/dmfs/jems/iterable/decorators/Chunked.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import java.util.Iterator;
+import java.util.Locale;
+
+
+/**
+ * An {@link Iterable} decorator which returns the elements of the decorated {@link Iterable} in chunks of a specific size.
+ *
+ * @author Marten Gajda
+ */
+public final class Chunked<T> implements Iterable<Iterable<T>>
+{
+    private final int mChunkSize;
+    private final Iterable<T> mDelegate;
+
+
+    public Chunked(int chunkSize, Iterable<T> delegate)
+    {
+        if (chunkSize <= 0)
+        {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Chunk size must be >0 but was %s", chunkSize));
+        }
+        mChunkSize = chunkSize;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public Iterator<Iterable<T>> iterator()
+    {
+        return new org.dmfs.jems.iterator.decorators.Chunked<>(mChunkSize, mDelegate.iterator());
+    }
+}

--- a/src/main/java/org/dmfs/jems/iterator/decorators/Chunked.java
+++ b/src/main/java/org/dmfs/jems/iterator/decorators/Chunked.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterator.decorators;
+
+import org.dmfs.iterators.AbstractBaseIterator;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+
+
+/**
+ * In {@link Iterator} decorator which returns the elements of the decorated {@link Iterator} in chunks of a specific size.
+ *
+ * @author Marten Gajda
+ */
+public final class Chunked<T> extends AbstractBaseIterator<Iterable<T>>
+{
+    private final int mChunkSize;
+    private final Iterator<T> mDelegate;
+
+
+    public Chunked(int chunkSize, Iterator<T> delegate)
+    {
+        if (chunkSize <= 0)
+        {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Chunk size must be >0 but was %s", chunkSize));
+        }
+        mChunkSize = chunkSize;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    public boolean hasNext()
+    {
+        return mDelegate.hasNext();
+    }
+
+
+    @Override
+    public Iterable<T> next()
+    {
+        List<T> result = new ArrayList<>(mChunkSize);
+        int remaining = mChunkSize;
+        do
+        {
+            result.add(mDelegate.next());
+        } while (mDelegate.hasNext() && --remaining > 0);
+        return result;
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterable/decorators/ChunkedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/ChunkedTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.BrokenFragileMatcher.isBroken;
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Chunked}.
+ *
+ * @author Marten Gajda
+ */
+public class ChunkedTest
+{
+    @Test
+    public void test()
+    {
+        // error case, illegal chunk size
+        assertThat(() -> new Chunked<>(-1, new Seq<>(1)), isBroken(IllegalArgumentException.class));
+        assertThat(() -> new Chunked<>(0, new Seq<>(1)), isBroken(IllegalArgumentException.class));
+
+        // edge case chunk size 1
+        assertThat(new Chunked<>(1, new Seq<>()), is(emptyIterable()));
+        assertThat(new Chunked<>(1, new Seq<>(1)), iteratesTo(iteratesTo(1)));
+        assertThat(new Chunked<>(1, new Seq<>(1, 2, 3)), iteratesTo(iteratesTo(1), iteratesTo(2), iteratesTo(3)));
+
+        // regular case chunk size >1
+        assertThat(new Chunked<>(3, new Seq<>()), is(emptyIterable()));
+        assertThat(new Chunked<>(3, new Seq<>(1)), iteratesTo(iteratesTo(1)));
+        assertThat(new Chunked<>(3, new Seq<>(1, 2, 3)), iteratesTo(iteratesTo(1, 2, 3)));
+        assertThat(new Chunked<>(3, new Seq<>(1, 2, 3, 4)), iteratesTo(iteratesTo(1, 2, 3), iteratesTo(4)));
+        assertThat(new Chunked<>(3, new Seq<>(1, 2, 3, 4, 5, 6)), iteratesTo(iteratesTo(1, 2, 3), iteratesTo(4, 5, 6)));
+        assertThat(new Chunked<>(3, new Seq<>(1, 2, 3, 4, 5, 6, 7)), iteratesTo(iteratesTo(1, 2, 3), iteratesTo(4, 5, 6), iteratesTo(7)));
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterator/decorators/ChunkedTest.java
+++ b/src/test/java/org/dmfs/jems/iterator/decorators/ChunkedTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterator.decorators;
+
+import org.dmfs.iterators.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.BrokenFragileMatcher.isBroken;
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher.emptyIterator;
+import static org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher.iteratorOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+
+/**
+ * Unit test for {@link Chunked}.
+ *
+ * @author Marten Gajda
+ */
+public class ChunkedTest
+{
+
+    @Test
+    public void test()
+    {
+        // error case, illegal chunk size
+        assertThat(() -> new Chunked<>(-1, new Seq<>(1)), isBroken(IllegalArgumentException.class));
+        assertThat(() -> new Chunked<>(0, new Seq<>(1)), isBroken(IllegalArgumentException.class));
+
+        // edge case chunk size 1
+        assertThat(() -> new Chunked<>(1, new Seq<>()), is(emptyIterator()));
+        assertThat(() -> new Chunked<>(1, new Seq<>(1)), is(iteratorOf(iteratesTo(1))));
+        assertThat(() -> new Chunked<>(1, new Seq<>(1, 2, 3)), is(iteratorOf(iteratesTo(1), iteratesTo(2), iteratesTo(3))));
+
+        // regular case chunk size >1
+        assertThat(() -> new Chunked<Integer>(3, new Seq<>()), is(emptyIterator()));
+        assertThat(() -> new Chunked<>(3, new Seq<>(1)), is(iteratorOf(iteratesTo(1))));
+        assertThat(() -> new Chunked<>(3, new Seq<>(1, 2, 3)), is(iteratorOf(iteratesTo(1, 2, 3))));
+        assertThat(() -> new Chunked<>(3, new Seq<>(1, 2, 3, 4)), is(iteratorOf(iteratesTo(1, 2, 3), iteratesTo(4))));
+        assertThat(() -> new Chunked<>(3, new Seq<>(1, 2, 3, 4, 5, 6)), is(iteratorOf(iteratesTo(1, 2, 3), iteratesTo(4, 5, 6))));
+        assertThat(() -> new Chunked<>(3, new Seq<>(1, 2, 3, 4, 5, 6, 7)), is(iteratorOf(iteratesTo(1, 2, 3), iteratesTo(4, 5, 6), iteratesTo(7))));
+    }
+}


### PR DESCRIPTION
Move Chunked Iterable and Iterator from OpenTasks to jems.
Add Tests for the Chunked Iterator.
Update `IteratorMatcher` to support the new tests.