### PR TITLE
Let IteratorMatcher also test whether remove throws, implements #190

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcher.java
@@ -91,6 +91,21 @@ public final class IteratorMatcher<T> extends TypeSafeDiagnosingMatcher<Generato
                     mismatchDescription.appendText(String.format(Locale.ENGLISH, "hasNext() flipped at index %d", index));
                     return false;
                 }
+                try
+                {
+                    testee.remove();
+                    mismatchDescription.appendText(String.format(Locale.ENGLISH, "remove() did not throw at index %d", index));
+                    return false;
+                }
+                catch (UnsupportedOperationException e)
+                {
+                    // pass
+                }
+                catch (Exception e)
+                {
+                    mismatchDescription.appendText(String.format(Locale.ENGLISH, "remove() threw wrong exception at index %d", index));
+                    return false;
+                }
             }
             T next = testee.next();
             Matcher<T> nextMatcher = matcherIterator.next();
@@ -113,6 +128,21 @@ public final class IteratorMatcher<T> extends TypeSafeDiagnosingMatcher<Generato
             if (testee.hasNext())
             {
                 mismatchDescription.appendText("hasNext() flipped after the last element");
+                return false;
+            }
+            try
+            {
+                testee.remove();
+                mismatchDescription.appendText("remove() did not throw after last element");
+                return false;
+            }
+            catch (UnsupportedOperationException e)
+            {
+                // pass
+            }
+            catch (Exception e)
+            {
+                mismatchDescription.appendText("remove() threw wrong exception after last element");
                 return false;
             }
         }

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcherTest.java
@@ -47,7 +47,8 @@ public class IteratorMatcherTest
     @Test
     public void testEmptyIterator()
     {
-        assertThat(emptyIterator(), matches(Collections::emptyIterator));
+        assertThat(emptyIterator(), matches(() -> new Unremovable<>(Collections.emptyIterator())));
+        assertThat(emptyIterator(), mismatches(Collections::emptyIterator, "remove() threw wrong exception after last element"));
         assertThat(IteratorMatcher.<String>emptyIterator(), mismatches(() -> singleton("a").iterator(), "had more than 0 elements"));
         assertThat(emptyIterator(), mismatches(() -> new Flipping<>(Collections.emptyIterator(), 30), "hasNext() flipped after the last element"));
         assertThat(emptyIterator(), mismatches(() -> new NonThrowing<>(Collections.emptyIterator()), "next() did not throw after hasNext() returned false"));
@@ -65,7 +66,8 @@ public class IteratorMatcherTest
         assertThat(iteratorOf("a"), mismatches(() -> new Flipping<>(singleton("a").iterator(), 20), "hasNext() flipped at index 0"));
         assertThat(iteratorOf("a"), mismatches(() -> new Flipping<>(singleton("a").iterator(), 120), "hasNext() flipped after the last element"));
         assertThat(iteratorOf("a"), mismatches(() -> singleton("b").iterator(), "was \"b\" at index 0"));
-        assertThat(iteratorOf("a"), mismatches(() -> asList("a", "b").iterator(), "had more than 1 elements"));
+        assertThat(iteratorOf("a"), mismatches(() -> new Unremovable<>(asList("a", "b").iterator()), "had more than 1 elements"));
+        assertThat(iteratorOf("a"), mismatches(() -> asList("a", "b").iterator(), "remove() threw wrong exception at index 0"));
         assertThat(iteratorOf("a"), mismatches(() -> new NonThrowing<>(singleton("a").iterator()), "next() did not throw after hasNext() returned false"));
         assertThat(iteratorOf("a"), mismatches(() -> new ReThrowing<>(singleton("a").iterator(), new IllegalStateException()),
                 "next() threw wrong exception after hasNext() returned false"));
@@ -76,17 +78,20 @@ public class IteratorMatcherTest
     @Test
     public void iterate3Elements()
     {
-        assertThat(iteratorOf("a", "b", "c"), matches(() -> asList("a", "b", "c").iterator()));
-        assertThat(iteratorOf("a", "b", "c"), mismatches(Collections::emptyIterator, "had only 0 elements"));
+        assertThat(iteratorOf("a", "b", "c"), matches(() -> new Unremovable<>(asList("a", "b", "c").iterator())));
+        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> new Unremovable<>(Collections.emptyIterator()), "had only 0 elements"));
         assertThat(iteratorOf("a", "b", "c"), mismatches(() -> new Flipping<>(asList("a", "b", "c").iterator(), 20), "hasNext() flipped at index 0"));
         assertThat(iteratorOf("a", "b", "c"), mismatches(() -> new Flipping<>(asList("a", "b", "c").iterator(), 220), "hasNext() flipped at index 2"));
         assertThat(iteratorOf("a", "b", "c"),
                 mismatches(() -> new Flipping<>(asList("a", "b", "c").iterator(), 320), "hasNext() flipped after the last element"));
-        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> asList("a", "b").iterator(), "had only 2 elements"));
-        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> asList("a", "c", "b").iterator(), "was \"c\" at index 1"));
-        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> asList("a", "b", "b").iterator(), "was \"b\" at index 2"));
-        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> asList("b", "b", "c").iterator(), "was \"b\" at index 0"));
-        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> asList("a", "b", "c", "c").iterator(), "had more than 3 elements"));
+        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> asList("a", "b").iterator(), "remove() threw wrong exception at index 0"));
+        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> new UnremovableFirst<>(asList("a", "b").iterator()), "remove() did not throw at index 0"));
+        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> new RemovableLast<>(asList("a", "b").iterator()), "remove() did not throw after last element"));
+        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> new Unremovable<>(asList("a", "b").iterator()), "had only 2 elements"));
+        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> new Unremovable<>(asList("a", "c", "b").iterator()), "was \"c\" at index 1"));
+        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> new Unremovable<>(asList("a", "b", "b").iterator()), "was \"b\" at index 2"));
+        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> new Unremovable<>(asList("b", "b", "c").iterator()), "was \"b\" at index 0"));
+        assertThat(iteratorOf("a", "b", "c"), mismatches(() -> new Unremovable<>(asList("a", "b", "c", "c").iterator()), "had more than 3 elements"));
         assertThat(iteratorOf("a", "b", "c"),
                 mismatches(() -> new NonThrowing<>(asList("a", "b", "c").iterator()), "next() did not throw after hasNext() returned false"));
         assertThat(iteratorOf("a", "b", "c"),
@@ -99,11 +104,14 @@ public class IteratorMatcherTest
     @Test
     public void variants()
     {
-        assertThat(iteratorOf(equalTo("a"), equalTo("b"), equalTo("c")), matches(() -> asList("a", "b", "c").iterator()));
-        assertThat(iteratorOf(new Seq<>(equalTo("a"), equalTo("b"), equalTo("c"))), matches(() -> asList("a", "b", "c").iterator()));
+        assertThat(iteratorOf(equalTo("a"), equalTo("b"), equalTo("c")), matches(() -> new Unremovable<>(asList("a", "b", "c").iterator())));
+        assertThat(iteratorOf(new Seq<>(equalTo("a"), equalTo("b"), equalTo("c"))), matches(() -> new Unremovable<>(asList("a", "b", "c").iterator())));
     }
 
 
+    /**
+     * {@link Iterator} decorator which doesn't throw when calling next after the last element.
+     */
     private static final class NonThrowing<T> extends AbstractBaseIterator<T>
     {
         private final Iterator<T> mDelegate;
@@ -137,6 +145,9 @@ public class IteratorMatcherTest
     }
 
 
+    /*
+     * {@link Iterator} decorator which throws the wrong exception in next();
+     */
     private static final class ReThrowing<T> extends AbstractBaseIterator<T>
     {
         private final Iterator<T> mDelegate;
@@ -172,6 +183,9 @@ public class IteratorMatcherTest
     }
 
 
+    /*
+     * {@link Iterator} decorator which has a broken hasNext() implementation which doesn't always return the same result.
+     */
     private static final class Flipping<T> extends AbstractBaseIterator<T>
     {
         private final Iterator<T> mDelegate;
@@ -203,6 +217,121 @@ public class IteratorMatcherTest
         public T next()
         {
             return mDelegate.next();
+        }
+    }
+
+
+    /**
+     * {@link Iterator} decorator which does not allow removing elements from the delegate.
+     */
+    private static final class Unremovable<T> implements Iterator<T>
+    {
+        private final Iterator<T> mDelegate;
+
+
+        private Unremovable(Iterator<T> delegate)
+        {
+            mDelegate = delegate;
+        }
+
+
+        @Override
+        public boolean hasNext()
+        {
+            return mDelegate.hasNext();
+        }
+
+
+        @Override
+        public T next()
+        {
+            return mDelegate.next();
+        }
+
+
+        @Override
+        public void remove()
+        {
+            throw new UnsupportedOperationException("Remove not supported");
+        }
+    }
+
+
+    /**
+     * {@link Iterator} decorator which pretends to allow removing the first element of the delegate.
+     */
+    private static final class UnremovableFirst<T> implements Iterator<T>
+    {
+        private final Iterator<T> mDelegate;
+        private int count;
+
+
+        private UnremovableFirst(Iterator<T> delegate)
+        {
+            mDelegate = delegate;
+        }
+
+
+        @Override
+        public boolean hasNext()
+        {
+            return mDelegate.hasNext();
+        }
+
+
+        @Override
+        public T next()
+        {
+            return mDelegate.next();
+        }
+
+
+        @Override
+        public void remove()
+        {
+            if (count++ < 1)
+            {
+                throw new UnsupportedOperationException("Remove not supported");
+            }
+        }
+    }
+
+
+    /**
+     * {@link Iterator} decorator which pretends to allow removing the last element of the delegate.
+     */
+    private static final class RemovableLast<T> implements Iterator<T>
+    {
+        private final Iterator<T> mDelegate;
+
+
+        private RemovableLast(Iterator<T> delegate)
+        {
+            mDelegate = delegate;
+        }
+
+
+        @Override
+        public boolean hasNext()
+        {
+            return mDelegate.hasNext();
+        }
+
+
+        @Override
+        public T next()
+        {
+            return mDelegate.next();
+        }
+
+
+        @Override
+        public void remove()
+        {
+            if (mDelegate.hasNext())
+            {
+                throw new UnsupportedOperationException("Remove not supported");
+            }
         }
     }
 }


### PR DESCRIPTION
In addition to test the normal Iterator mode, we also want to ensure none of our `Iterator`s supports the remove method and throws when called.