### PR TITLE
Clustered decorators, implements #197

### DIFF
--- a/src/main/java/org/dmfs/jems/iterable/decorators/Clustered.java
+++ b/src/main/java/org/dmfs/jems/iterable/decorators/Clustered.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import java.util.Comparator;
+import java.util.Iterator;
+
+
+/**
+ * An {@link Iterable} decorator which clusters consecutive elements of another {@link Iterable} by the result of a {@link Comparator}. Consecutive elements
+ * which compare to {@code 0} go into the same cluster. The original order of the elements remains the same.
+ *
+ * <pre>{@code
+ * Clustered(Comparator.naturalOrder(), [5, 5, 5, 3, 3, 4, 4, 4, 5, 5, 2, 2]) ->
+ * [
+ *   [5, 5, 5],
+ *   [3, 3],
+ *   [4, 4, 4],
+ *   [5, 5],
+ *   [2, 2]
+ * ]
+ * }</pre>
+ *
+ * @author Marten Gajda
+ */
+public final class Clustered<T> implements Iterable<Iterable<T>>
+{
+    private final Iterable<T> mDelegate;
+    private final Comparator<? super T> mComparator;
+
+
+    public Clustered(Comparator<? super T> comparator, Iterable<T> delegate)
+    {
+        mDelegate = delegate;
+        mComparator = comparator;
+    }
+
+
+    @Override
+    public Iterator<Iterable<T>> iterator()
+    {
+        return new org.dmfs.jems.iterator.decorators.Clustered<T>(mComparator, mDelegate.iterator());
+    }
+}

--- a/src/main/java/org/dmfs/jems/iterator/decorators/Clustered.java
+++ b/src/main/java/org/dmfs/jems/iterator/decorators/Clustered.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterator.decorators;
+
+import org.dmfs.jems.optional.Optional;
+import org.dmfs.jems.optional.adapters.Next;
+import org.dmfs.jems.optional.elementary.Present;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.dmfs.jems.optional.elementary.Absent.absent;
+
+
+/**
+ * An {@link Iterator} decorator which clusters consecutive elements of another {@link Iterator} by the result of a {@link Comparator}. Consecutive elements
+ * which compare to {@code 0} go into the same cluster. The original order of the elements remains the same.
+ *
+ * <pre>{@code
+ * Clustered(Comparator.naturalOrder(), [5, 5, 5, 3, 3, 4, 4, 4, 5, 5, 2, 2]) ->
+ * [
+ *   [5, 5, 5],
+ *   [3, 3],
+ *   [4, 4, 4],
+ *   [5, 5],
+ *   [2, 2]
+ * ]
+ * }</pre>
+ *
+ * @author Marten Gajda
+ */
+public final class Clustered<T> implements Iterator<Iterable<T>>
+{
+    private final Iterator<T> mDelegate;
+    private final Comparator<? super T> mComparator;
+    private Optional<T> mNext;
+
+
+    public Clustered(Comparator<? super T> comparator, Iterator<T> delegate)
+    {
+        mDelegate = delegate;
+        mComparator = comparator;
+        mNext = new Next<>(mDelegate);
+    }
+
+
+    @Override
+    public boolean hasNext()
+    {
+        return mNext.isPresent();
+    }
+
+
+    @Override
+    public Iterable<T> next()
+    {
+        T first = mNext.value();
+
+        List<T> result = new LinkedList<>();
+        result.add(first);
+        boolean hasMore;
+        T next = null;
+
+        // add elements as long as they are equal to the first one
+        while ((hasMore = mDelegate.hasNext()) && mComparator.compare(first, next = mDelegate.next()) == 0)
+        {
+            result.add(next);
+        }
+
+        mNext = hasMore ? new Present<>(next) : absent();
+        return result;
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterable/decorators/ClusteredTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/ClusteredTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import java.util.Comparator;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Clustered}.
+ *
+ * @author Marten Gajda
+ */
+public class ClusteredTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new Clustered<String>(Comparator.naturalOrder(), EmptyIterable.instance()), emptyIterable());
+        assertThat(new Clustered<>(Comparator.naturalOrder(), new Seq<>(1)), iteratesTo(iteratesTo(1)));
+        assertThat(new Clustered<>(Comparator.naturalOrder(), new Seq<>(1, 1)), iteratesTo(iteratesTo(1, 1)));
+        assertThat(new Clustered<>(Comparator.naturalOrder(), new Seq<>(1, 2, 3)), iteratesTo(iteratesTo(1), iteratesTo(2), iteratesTo(3)));
+        assertThat(new Clustered<>(Comparator.naturalOrder(), new Seq<>(1, 1, 2, 2, 3, 3)), iteratesTo(iteratesTo(1, 1), iteratesTo(2, 2), iteratesTo(3, 3)));
+        assertThat(new Clustered<>(Comparator.naturalOrder(), new Seq<>(1, 1, 2, 2, 1, 1)), iteratesTo(iteratesTo(1, 1), iteratesTo(2, 2), iteratesTo(1, 1)));
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterator/decorators/ClusteredTest.java
+++ b/src/test/java/org/dmfs/jems/iterator/decorators/ClusteredTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterator.decorators;
+
+import org.dmfs.iterators.EmptyIterator;
+import org.dmfs.iterators.elementary.Seq;
+import org.junit.Test;
+
+import java.util.Comparator;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher.emptyIterator;
+import static org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher.iteratorOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Clustered}.
+ *
+ * @author Marten Gajda
+ */
+public class ClusteredTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(() -> new Clustered<String>(Comparator.naturalOrder(), EmptyIterator.instance()),
+                emptyIterator());
+        assertThat(() -> new Clustered<>(Comparator.naturalOrder(), new Seq<>(1)),
+                iteratorOf(iteratesTo(1)));
+        assertThat(() -> new Clustered<>(Comparator.naturalOrder(), new Seq<>(1, 1)),
+                iteratorOf(iteratesTo(1, 1)));
+        assertThat(() -> new Clustered<>(Comparator.naturalOrder(), new Seq<>(1, 2, 3)),
+                iteratorOf(iteratesTo(1), iteratesTo(2), iteratesTo(3)));
+        assertThat(() -> new Clustered<>(Comparator.naturalOrder(), new Seq<>(1, 1, 2, 2, 3, 3)),
+                iteratorOf(iteratesTo(1, 1), iteratesTo(2, 2), iteratesTo(3, 3)));
+        assertThat(() -> new Clustered<>(Comparator.naturalOrder(), new Seq<>(1, 1, 2, 2, 1, 1)),
+                iteratorOf(iteratesTo(1, 1), iteratesTo(2, 2), iteratesTo(1, 1)));
+    }
+}


### PR DESCRIPTION
Implements Clustered decorators for Iterable and Iterator which clusters elements based on the result of a comparable.