### PR TITLE
Add Sorted Iterable decorators, implements #68

### DIFF
--- a/src/main/java/org/dmfs/jems/iterable/decorators/Ascending.java
+++ b/src/main/java/org/dmfs/jems/iterable/decorators/Ascending.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import org.dmfs.iterables.decorators.DelegatingIterable;
+
+
+/**
+ * An {@link Iterable} decorator which returns the elements of the delegate in their natural ascending order.
+ *
+ * @author Marten Gajda
+ */
+public final class Ascending<T extends Comparable<? super T>> extends DelegatingIterable<T>
+{
+    public Ascending(Iterable<T> delegate)
+    {
+        // note Comparator.naturalOrder doesn't exist on Android SDK Level < 24 hence we don't use it here
+        super(new Sorted<>((l, r) -> l.compareTo(r), delegate));
+    }
+}

--- a/src/main/java/org/dmfs/jems/iterable/decorators/Descending.java
+++ b/src/main/java/org/dmfs/jems/iterable/decorators/Descending.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import org.dmfs.iterables.decorators.DelegatingIterable;
+
+
+/**
+ * An {@link Iterable} decorator which returns the elements of the delegate in their natural descending order.
+ *
+ * @author Marten Gajda
+ */
+public final class Descending<T extends Comparable<? super T>> extends DelegatingIterable<T>
+{
+    public Descending(Iterable<T> delegate)
+    {
+        // note Comparator.reverseOrder doesn't exist on Android SDK Level < 24 hence we don't use it here
+        super(new Sorted<>((l, r) -> r.compareTo(l), delegate));
+    }
+}

--- a/src/main/java/org/dmfs/jems/iterable/decorators/Sorted.java
+++ b/src/main/java/org/dmfs/jems/iterable/decorators/Sorted.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import org.dmfs.jems.single.elementary.Reduced;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.TreeSet;
+
+
+/**
+ * An {@link Iterable} decorator which returns the elements of the delegate in a sorted order, determined by a given {@link Comparator}.
+ *
+ * @author Marten Gajda
+ */
+public final class Sorted<T> implements Iterable<T>
+{
+    private final Iterable<T> mDelegate;
+    private final Comparator<T> mComparator;
+
+
+    public Sorted(Comparator<T> comparator, Iterable<T> delegate)
+    {
+        mDelegate = delegate;
+        mComparator = comparator;
+    }
+
+
+    @Override
+    public Iterator<T> iterator()
+    {
+        return new Reduced<>(new TreeSet<>(mComparator), (r, v) -> {
+            r.add(v);
+            return r;
+        }, mDelegate).value().iterator();
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterable/decorators/AscendingTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/AscendingTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Ascending}.
+ *
+ * @author Marten Gajda
+ */
+public class AscendingTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new Ascending<String>(new Seq<>()), is(emptyIterable()));
+        assertThat(new Ascending<>(new Seq<>("z")), iteratesTo("z"));
+        assertThat(new Ascending<>(new Seq<>("z", "x", "y")), iteratesTo("x", "y", "z"));
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterable/decorators/DescendingTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/DescendingTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Descending}.
+ *
+ * @author Marten Gajda
+ */
+public class DescendingTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new Descending<String>(new Seq<>()), is(emptyIterable()));
+        assertThat(new Descending<>(new Seq<>("z")), iteratesTo("z"));
+        assertThat(new Descending<>(new Seq<>("x", "y", "z")), iteratesTo("z", "y", "x"));
+    }
+}

--- a/src/test/java/org/dmfs/jems/iterable/decorators/SortedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/SortedTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.decorators;
+
+import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.iterables.elementary.Seq;
+import org.junit.Test;
+
+import java.util.Comparator;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link Sorted}.
+ *
+ * @author Marten Gajda
+ */
+public class SortedTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new Sorted<>(Comparator.naturalOrder(), new EmptyIterable<String>()), is(emptyIterable()));
+        assertThat(new Sorted<>(Comparator.naturalOrder(), new Seq<>(7, 4, 1, 3, 6, 9)), iteratesTo(1, 3, 4, 6, 7, 9));
+        assertThat(new Sorted<>(Comparator.reverseOrder(), new Seq<>(7, 4, 1, 3, 6, 9)), iteratesTo(9, 7, 6, 4, 3, 1));
+    }
+}


### PR DESCRIPTION
This adds three decorators to sort Iterables, one which sorts Comparables by their natural order (ascending and descending) and one which sorts by a given Comparator.