### PR TITLE
Add Reduced Ctor with Generator, fixes #95

### DIFF
--- a/src/main/java/org/dmfs/jems/single/elementary/Digest.java
+++ b/src/main/java/org/dmfs/jems/single/elementary/Digest.java
@@ -90,7 +90,7 @@ public final class Digest implements Single<byte[]>
     @Override
     public byte[] value()
     {
-        return new Reduced<>(mMessageDigestFactory.newInstance(), new DigestFunction(), mParts).value().digest();
+        return new Reduced<Single<byte[]>, MessageDigest>(mMessageDigestFactory::newInstance, new DigestFunction(), mParts).value().digest();
     }
 
 

--- a/src/main/java/org/dmfs/jems/single/elementary/Reduced.java
+++ b/src/main/java/org/dmfs/jems/single/elementary/Reduced.java
@@ -18,6 +18,7 @@
 package org.dmfs.jems.single.elementary;
 
 import org.dmfs.jems.function.BiFunction;
+import org.dmfs.jems.generator.Generator;
 import org.dmfs.jems.single.Single;
 
 
@@ -30,14 +31,24 @@ import org.dmfs.jems.single.Single;
  */
 public final class Reduced<Value, Result> implements Single<Result>
 {
-    private final Result mInitialValue;
+    private final Generator<Result> mInitialValue;
     private final Iterable<Value> mIterable;
     private final BiFunction<Result, Value, Result> mFunction;
 
 
+    /**
+     * @deprecated in favor of {@link Reduced#Reduced(Generator, BiFunction, Iterable)}.
+     */
+    @Deprecated
     public Reduced(Result initialValue, BiFunction<Result, Value, Result> accumulatorFunction, Iterable<Value> iterable)
     {
-        mInitialValue = initialValue;
+        this(() -> initialValue, accumulatorFunction, iterable);
+    }
+
+
+    public Reduced(Generator<Result> initialValueGenerator, BiFunction<Result, Value, Result> accumulatorFunction, Iterable<Value> iterable)
+    {
+        mInitialValue = initialValueGenerator;
         mIterable = iterable;
         mFunction = accumulatorFunction;
     }
@@ -46,7 +57,7 @@ public final class Reduced<Value, Result> implements Single<Result>
     @Override
     public Result value()
     {
-        Result result = mInitialValue;
+        Result result = mInitialValue.next();
         for (Value value : mIterable)
         {
             result = mFunction.value(result, value);

--- a/src/test/java/org/dmfs/jems/single/elementary/ReducedTest.java
+++ b/src/test/java/org/dmfs/jems/single/elementary/ReducedTest.java
@@ -23,8 +23,8 @@ import org.dmfs.iterables.elementary.Seq;
 import org.dmfs.jems.function.BiFunction;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.SingleMatcher.hasValue;
 import static org.dmfs.jems.mockito.doubles.TestDoubles.failingMock;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
@@ -35,40 +35,58 @@ import static org.junit.Assert.assertThat;
 public class ReducedTest
 {
     @Test
-    public void testEmptyIterable() throws Exception
+    public void testEmptyIterable()
     {
         Object dummy = new Object();
-        assertThat(new Reduced(dummy, failingMock(BiFunction.class), EmptyIterable.instance()).value(), sameInstance(dummy));
+        assertThat(
+                new Reduced<Object, Object>(dummy, failingMock(BiFunction.class), EmptyIterable.instance()),
+                hasValue(sameInstance(dummy)));
     }
 
 
     @Test
-    public void testSingletonIterable() throws Exception
+    public void testSingletonIterable()
     {
-        assertThat(new Reduced<>("0", new BiFunction<String, String, String>()
-        {
-            @Override
-            public String value(String s, String s2)
-            {
-                // append new element to reduced ones
-                return s + s2;
-            }
-        }, new SingletonIterable<String>("1")).value(), is("01"));
+        assertThat(
+                new Reduced<>("0", (s, s2) -> s + s2, new SingletonIterable<>("1")),
+                hasValue("01"));
     }
 
 
     @Test
-    public void testSeqIterable() throws Exception
+    public void testSeqIterable()
     {
-        assertThat(new Reduced<>("0", new BiFunction<String, String, String>()
-        {
-            @Override
-            public String value(String s, String s2)
-            {
-                // append new element to reduced ones
-                return s + s2;
-            }
-        }, new Seq<>("1", "2", "3", "4")).value(), is("01234"));
+        assertThat(
+                new Reduced<>("0", (s, s2) -> s + s2, new Seq<>("1", "2", "3", "4")),
+                hasValue("01234"));
+    }
+
+
+    @Test
+    public void testGeneratorEmptyIterable()
+    {
+        Object dummy = new Object();
+        assertThat(
+                new Reduced<Object, Object>(() -> dummy, failingMock(BiFunction.class), EmptyIterable.instance()),
+                hasValue(sameInstance(dummy)));
+    }
+
+
+    @Test
+    public void testGeneratorSingletonIterable()
+    {
+        assertThat(
+                new Reduced<String, String>(() -> "0", (s, s2) -> s + s2, new SingletonIterable<>("1")),
+                hasValue("01"));
+    }
+
+
+    @Test
+    public void testGeneratorSeqIterable()
+    {
+        assertThat(
+                new Reduced<String, String>(() -> "0", (s, s2) -> s + s2, new Seq<>("1", "2", "3", "4")),
+                hasValue("01234"));
     }
 
 }


### PR DESCRIPTION
This adds another constructor to `Reduced` which takes a `Generator` instead of a plain value to get the initial value. This makes the class immutable, even when operation on mutable values.