### PR TITLE
Allow to specify a length on Seq, implements #219

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceMatcher.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.hamcrest.matchers;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.AllOf;
 

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceSubSequenceMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/CharSequenceSubSequenceMatcher.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.hamcrest.matchers;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/GeneratableMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/GeneratableMatcher.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.hamcrest.matchers;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.generatable.Generatable;
 import org.dmfs.jems.generator.Generator;
 import org.dmfs.jems.iterable.decorators.Mapped;

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/StackMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/StackMatcher.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.hamcrest.matchers;
 
 import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.iterators.Function;
 import org.dmfs.jems.iterable.elementary.StackIterable;
 import org.dmfs.jems.optional.Optional;

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcher.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.hamcrest.matchers.iterator;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.generator.Generator;
 import org.dmfs.jems.iterable.decorators.Mapped;
 import org.hamcrest.Description;

--- a/jems-testing/src/main/java/org/dmfs/jems/mocks/MockFunction.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/mocks/MockFunction.java
@@ -20,7 +20,7 @@ package org.dmfs.jems.mocks;
 import org.dmfs.iterables.SingletonIterable;
 import org.dmfs.iterables.composite.PairZipped;
 import org.dmfs.iterables.decorators.Filtered;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.iterators.Filter;
 import org.dmfs.iterators.Function;
 import org.dmfs.jems.pair.Pair;

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/GeneratableMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/GeneratableMatcherTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.hamcrest.matchers;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.generatable.Generatable;
 import org.dmfs.jems.generator.Generator;
 import org.hamcrest.Description;

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcherTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.hamcrest.matchers.iterator;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.iterators.AbstractBaseIterator;
 import org.dmfs.iterators.EmptyIterator;
 import org.junit.Test;

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/throwable/ThrowableMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/throwable/ThrowableMatcherTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.hamcrest.matchers.throwable;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;

--- a/jems-testing/src/test/java/org/dmfs/jems/mocks/MockFunctionTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/mocks/MockFunctionTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.mocks;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.iterators.Function;
 import org.dmfs.jems.pair.Pair;
 import org.dmfs.jems.pair.elementary.ValuePair;

--- a/src/main/java/org/dmfs/iterables/ArrayIterable.java
+++ b/src/main/java/org/dmfs/iterables/ArrayIterable.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.iterables;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.iterators.ArrayIterator;
 
 import java.util.Iterator;

--- a/src/main/java/org/dmfs/iterables/decorators/Flattened.java
+++ b/src/main/java/org/dmfs/iterables/decorators/Flattened.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.iterables.decorators;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.iterable.composite.Joined;
 
 import java.util.Iterator;

--- a/src/main/java/org/dmfs/iterables/elementary/PresentValues.java
+++ b/src/main/java/org/dmfs/iterables/elementary/PresentValues.java
@@ -18,6 +18,7 @@
 package org.dmfs.iterables.elementary;
 
 import org.dmfs.iterables.SingletonIterable;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.optional.Optional;
 
 import java.util.Iterator;

--- a/src/main/java/org/dmfs/iterables/elementary/Seq.java
+++ b/src/main/java/org/dmfs/iterables/elementary/Seq.java
@@ -27,7 +27,9 @@ import java.util.Iterator;
  *         The type of the iterated elements.
  *
  * @author Marten Gajda
+ * @deprecated in favour of {@link org.dmfs.jems.iterable.elementary.Seq}
  */
+@Deprecated
 public final class Seq<T> implements Iterable<T>
 {
     private final T[] mArray;

--- a/src/main/java/org/dmfs/iterators/ArrayIterator.java
+++ b/src/main/java/org/dmfs/iterators/ArrayIterator.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.iterators;
 
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 
 import java.util.Iterator;
 

--- a/src/main/java/org/dmfs/iterators/decorators/Flattened.java
+++ b/src/main/java/org/dmfs/iterators/decorators/Flattened.java
@@ -19,7 +19,7 @@ package org.dmfs.iterators.decorators;
 
 import org.dmfs.iterators.AbstractBaseIterator;
 import org.dmfs.iterators.EmptyIterator;
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;

--- a/src/main/java/org/dmfs/iterators/decorators/Serialized.java
+++ b/src/main/java/org/dmfs/iterators/decorators/Serialized.java
@@ -19,7 +19,7 @@ package org.dmfs.iterators.decorators;
 
 import org.dmfs.iterators.AbstractBaseIterator;
 import org.dmfs.iterators.EmptyIterator;
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;

--- a/src/main/java/org/dmfs/iterators/elementary/PresentValues.java
+++ b/src/main/java/org/dmfs/iterators/elementary/PresentValues.java
@@ -20,6 +20,7 @@ package org.dmfs.iterators.elementary;
 import org.dmfs.iterators.AbstractBaseIterator;
 import org.dmfs.iterators.SingletonIterator;
 import org.dmfs.iterators.decorators.Filtered;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.dmfs.jems.optional.Optional;
 
 import java.util.Iterator;

--- a/src/main/java/org/dmfs/jems/iterable/composite/Joined.java
+++ b/src/main/java/org/dmfs/jems/iterable/composite/Joined.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.iterable.composite;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 
 import java.util.Iterator;
 

--- a/src/main/java/org/dmfs/jems/iterable/elementary/Seq.java
+++ b/src/main/java/org/dmfs/jems/iterable/elementary/Seq.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.elementary;
+
+import java.util.Iterator;
+
+
+/**
+ * {@link Iterable} sequence of values.
+ *
+ * @param <T>
+ *         The type of the iterated elements.
+ *
+ * @author Marten Gajda
+ */
+public final class Seq<T> implements Iterable<T>
+{
+    private final T[] mValues;
+    private final int mCount;
+
+
+    /**
+     * Creates an {@link Iterable} of the given elements.
+     */
+    @SafeVarargs
+    public Seq(T... values)
+    {
+        this(values.length, values);
+    }
+
+
+    /**
+     * Creates an {@link Iterable} of the first {@code count} elements of the given array.
+     */
+    public Seq(int count, T[] values)
+    {
+        if (count < 0)
+        {
+            throw new ArrayIndexOutOfBoundsException(String.format("Count must not be less than 0, was %d", count));
+        }
+        if (count > values.length)
+        {
+            throw new ArrayIndexOutOfBoundsException(
+                    String.format("Count must not be higher than the number of values (%d), was %d", values.length, count));
+        }
+        mCount = count;
+        mValues = values;
+    }
+
+
+    @Override
+    public Iterator<T> iterator()
+    {
+        return new org.dmfs.jems.iterator.elementary.Seq<>(mCount, mValues);
+    }
+}

--- a/src/main/java/org/dmfs/jems/iterator/elementary/Seq.java
+++ b/src/main/java/org/dmfs/jems/iterator/elementary/Seq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 dmfs GmbH
+ * Copyright 2019 dmfs GmbH
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.dmfs.iterators.elementary;
+package org.dmfs.jems.iterator.elementary;
 
 import org.dmfs.iterators.AbstractBaseIterator;
 
@@ -27,48 +27,62 @@ import java.util.NoSuchElementException;
  * An {@link Iterator} of a sequence of values.
  *
  * @param <E>
- *         The type of the values in the array.
+ *         The type of the iterated values.
  *
  * @author Marten Gajda
- * @deprecated in favour of {@link org.dmfs.jems.iterator.elementary.Seq}
  */
-@Deprecated
 public final class Seq<E> extends AbstractBaseIterator<E>
 {
     private final E[] mValues;
+    private final int mCount;
     private int mNext;
 
 
     /**
-     * Creates an {@link Iterator} which iterates all values in the given array.
-     *
-     * @param array
-     *         The array.
+     * Creates an {@link Iterator} of the given elements.
      */
     @SafeVarargs
-    public Seq(E... array)
+    public Seq(E... values)
     {
-        mValues = array;
+        this(values.length, values);
+    }
+
+
+    /**
+     * Creates an {@link Iterator} of the first {@code count} elements of the given array.
+     */
+    public Seq(int count, E[] values)
+    {
+        if (count < 0)
+        {
+            throw new ArrayIndexOutOfBoundsException(String.format("Count must not be less than 0, was %d", count));
+        }
+        if (count > values.length)
+        {
+            throw new ArrayIndexOutOfBoundsException(
+                    String.format("Count must not be higher than the number of values (%d), was %d", values.length, count));
+        }
+        mCount = count;
+        mValues = values;
     }
 
 
     @Override
     public boolean hasNext()
     {
-        return mNext < mValues.length;
+        return mNext < mCount;
     }
 
 
     @Override
     public E next()
     {
-        E[] values = mValues;
         int next = mNext;
-        if (next >= values.length)
+        if (next >= mCount)
         {
             throw new NoSuchElementException("No more elements to iterate");
         }
         mNext = next + 1;
-        return values[next];
+        return mValues[next];
     }
 }

--- a/src/main/java/org/dmfs/jems/optional/adapters/FirstPresent.java
+++ b/src/main/java/org/dmfs/jems/optional/adapters/FirstPresent.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.optional.adapters;
 
 import org.dmfs.iterables.elementary.PresentValues;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.decorators.DelegatingOptional;
 

--- a/src/main/java/org/dmfs/jems/predicate/composite/AllOf.java
+++ b/src/main/java/org/dmfs/jems/predicate/composite/AllOf.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.predicate.composite;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.predicate.Predicate;
 
 

--- a/src/main/java/org/dmfs/jems/predicate/composite/AnyOf.java
+++ b/src/main/java/org/dmfs/jems/predicate/composite/AnyOf.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.predicate.composite;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.predicate.Predicate;
 
 

--- a/src/main/java/org/dmfs/jems/predicate/composite/NoneOf.java
+++ b/src/main/java/org/dmfs/jems/predicate/composite/NoneOf.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.predicate.composite;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.predicate.Predicate;
 import org.dmfs.jems.predicate.elementary.DelegatingPredicate;
 

--- a/src/main/java/org/dmfs/jems/single/elementary/Digest.java
+++ b/src/main/java/org/dmfs/jems/single/elementary/Digest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.single.elementary;
 
 import org.dmfs.iterables.decorators.Mapped;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.iterators.Function;
 import org.dmfs.jems.function.BiFunction;
 import org.dmfs.jems.function.elementary.SingleFunction;

--- a/src/main/java/org/dmfs/optional/adapters/FirstPresent.java
+++ b/src/main/java/org/dmfs/optional/adapters/FirstPresent.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.optional.adapters;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.optional.First;
 import org.dmfs.optional.Optional;
 import org.dmfs.optional.decorators.DelegatingOptional;

--- a/src/main/java/org/dmfs/optional/iterable/PresentValues.java
+++ b/src/main/java/org/dmfs/optional/iterable/PresentValues.java
@@ -18,7 +18,7 @@
 package org.dmfs.optional.iterable;
 
 import org.dmfs.iterables.SingletonIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.optional.Optional;
 
 import java.util.Iterator;

--- a/src/main/java/org/dmfs/optional/iterator/PresentValues.java
+++ b/src/main/java/org/dmfs/optional/iterator/PresentValues.java
@@ -21,7 +21,7 @@ import org.dmfs.iterators.AbstractBaseIterator;
 import org.dmfs.iterators.Filter;
 import org.dmfs.iterators.SingletonIterator;
 import org.dmfs.iterators.decorators.Filtered;
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.dmfs.optional.Optional;
 
 import java.util.Iterator;

--- a/src/test/java/org/dmfs/iterables/composite/PairZippedTest.java
+++ b/src/test/java/org/dmfs/iterables/composite/PairZippedTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.iterables.composite;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.pair.Pair;
 import org.dmfs.jems.pair.elementary.ValuePair;
 import org.hamcrest.Description;

--- a/src/test/java/org/dmfs/iterables/composite/ZippedTest.java
+++ b/src/test/java/org/dmfs/iterables/composite/ZippedTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.iterables.composite;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.function.BiFunction;
 import org.junit.Test;
 

--- a/src/test/java/org/dmfs/iterables/decorators/FluentIterableTest.java
+++ b/src/test/java/org/dmfs/iterables/decorators/FluentIterableTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.iterables.decorators;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;

--- a/src/test/java/org/dmfs/iterables/decorators/SievedTest.java
+++ b/src/test/java/org/dmfs/iterables/decorators/SievedTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.iterables.decorators;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.predicate.elementary.Anything;
 import org.dmfs.jems.predicate.elementary.Equals;
 import org.dmfs.jems.predicate.elementary.Nothing;

--- a/src/test/java/org/dmfs/iterables/elementary/OptionalIterableTest.java
+++ b/src/test/java/org/dmfs/iterables/elementary/OptionalIterableTest.java
@@ -17,6 +17,7 @@
 
 package org.dmfs.iterables.elementary;
 
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.optional.elementary.Present;
 import org.hamcrest.Matchers;
 import org.junit.Test;

--- a/src/test/java/org/dmfs/iterables/elementary/PresentValuesTest.java
+++ b/src/test/java/org/dmfs/iterables/elementary/PresentValuesTest.java
@@ -17,6 +17,7 @@
 
 package org.dmfs.iterables.elementary;
 
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.optional.elementary.Present;
 import org.junit.Test;
 

--- a/src/test/java/org/dmfs/iterators/SerialIterableIteratorTest.java
+++ b/src/test/java/org/dmfs/iterators/SerialIterableIteratorTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.iterators;
 
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/src/test/java/org/dmfs/iterators/SerialIteratorIteratorTest.java
+++ b/src/test/java/org/dmfs/iterators/SerialIteratorIteratorTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.iterators;
 
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/src/test/java/org/dmfs/iterators/composite/PairZippedTest.java
+++ b/src/test/java/org/dmfs/iterators/composite/PairZippedTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.iterators.composite;
 
 import org.dmfs.iterators.EmptyIterator;
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher;
 import org.dmfs.jems.pair.Pair;
 import org.junit.Test;

--- a/src/test/java/org/dmfs/iterators/decorators/FluentTest.java
+++ b/src/test/java/org/dmfs/iterators/decorators/FluentTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.iterators.decorators;
 
 import org.dmfs.iterators.EmptyIterator;
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher.emptyIterator;

--- a/src/test/java/org/dmfs/iterators/decorators/SievedTest.java
+++ b/src/test/java/org/dmfs/iterators/decorators/SievedTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.iterators.decorators;
 
 import org.dmfs.iterators.EmptyIterator;
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.dmfs.jems.predicate.elementary.Anything;
 import org.dmfs.jems.predicate.elementary.Equals;
 import org.dmfs.jems.predicate.elementary.Nothing;

--- a/src/test/java/org/dmfs/iterators/elementary/PresentValuesTest.java
+++ b/src/test/java/org/dmfs/iterators/elementary/PresentValuesTest.java
@@ -18,6 +18,7 @@
 package org.dmfs.iterators.elementary;
 
 import org.dmfs.iterators.EmptyIterator;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.dmfs.jems.optional.elementary.Absent;
 import org.dmfs.jems.optional.elementary.Present;
 import org.junit.Test;

--- a/src/test/java/org/dmfs/jems/generatable/elementary/SequenceTest.java
+++ b/src/test/java/org/dmfs/jems/generatable/elementary/SequenceTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.generatable.elementary;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.generatable.Generatable;
 import org.dmfs.jems.iterable.decorators.Mapped;
 import org.hamcrest.Matchers;

--- a/src/test/java/org/dmfs/jems/iterable/composite/DiffTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/composite/DiffTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.iterable.composite;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.function.BiFunction;
 import org.junit.Test;
 

--- a/src/test/java/org/dmfs/jems/iterable/composite/JoinedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/composite/JoinedTest.java
@@ -19,7 +19,7 @@ package org.dmfs.jems.iterable.composite;
 
 import org.dmfs.iterables.EmptyIterable;
 import org.dmfs.iterables.SingletonIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.contains;

--- a/src/test/java/org/dmfs/jems/iterable/decorators/AscendingTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/AscendingTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.iterable.decorators;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;

--- a/src/test/java/org/dmfs/jems/iterable/decorators/ChunkedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/ChunkedTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.iterable.decorators;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.BrokenFragileMatcher.isBroken;

--- a/src/test/java/org/dmfs/jems/iterable/decorators/ClusteredTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/ClusteredTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.iterable.decorators;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.junit.Test;
 
 import java.util.Comparator;

--- a/src/test/java/org/dmfs/jems/iterable/decorators/DescendingTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/DescendingTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.iterable.decorators;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;

--- a/src/test/java/org/dmfs/jems/iterable/decorators/ExpandedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/ExpandedTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.iterable.decorators;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.function.Function;
 import org.hamcrest.Matchers;
 import org.junit.Test;

--- a/src/test/java/org/dmfs/jems/iterable/decorators/FrozenTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/FrozenTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.iterable.decorators;
 
 import org.dmfs.iterators.AbstractBaseIterator;
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.junit.Test;
 
 import java.util.Iterator;

--- a/src/test/java/org/dmfs/jems/iterable/decorators/MappedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/MappedTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.iterable.decorators;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.function.Function;
 import org.dmfs.jems.mockito.doubles.TestDoubles;
 import org.hamcrest.Matchers;

--- a/src/test/java/org/dmfs/jems/iterable/decorators/NumberedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/NumberedTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.iterable.decorators;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;

--- a/src/test/java/org/dmfs/jems/iterable/decorators/SortedTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/decorators/SortedTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.iterable.decorators;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.junit.Test;
 
 import java.util.Comparator;

--- a/src/test/java/org/dmfs/jems/iterable/elementary/SeqTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/elementary/SeqTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterable.elementary;
+
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.BrokenFragileMatcher.throwing;
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.dmfs.jems.hamcrest.matchers.throwable.ThrowableMatcher.throwable;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test of {@link Seq}.
+ *
+ * @author Marten Gajda
+ */
+public class SeqTest
+{
+    @Test
+    public void testIterator() throws Exception
+    {
+        assertThat(new Seq<>(), emptyIterable());
+        assertThat(new Seq<>("1"), iteratesTo("1"));
+        assertThat(new Seq<>("1", "2", "3"), iteratesTo("1", "2", "3"));
+
+        assertThat(new Seq<>(0, new String[] {}), emptyIterable());
+        assertThat(new Seq<>(0, new String[] { "1", "2", "3" }), emptyIterable());
+        assertThat(new Seq<>(1, new String[] { "1" }), iteratesTo("1"));
+        assertThat(new Seq<>(1, new String[] { "1", "2", "3" }), iteratesTo("1"));
+        assertThat(new Seq<>(3, new String[] { "1", "2", "3" }), iteratesTo("1", "2", "3"));
+
+        assertThat(() -> new Seq<>(1, new String[] {}), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+        assertThat(() -> new Seq<>(4, new String[] { "1", "2", "3" }), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+        assertThat(() -> new Seq<>(4, new String[] { "1" }), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+        assertThat(() -> new Seq<>(-1, new String[] {}), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+        assertThat(() -> new Seq<>(-1, new String[] { "1", "2", "3" }), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+        assertThat(() -> new Seq<>(-2, new String[] { "1" }), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+    }
+
+}

--- a/src/test/java/org/dmfs/jems/iterator/composite/DiffTest.java
+++ b/src/test/java/org/dmfs/jems/iterator/composite/DiffTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.iterator.composite;
 
 import org.dmfs.iterators.EmptyIterator;
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher;
 import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.pair.Pair;

--- a/src/test/java/org/dmfs/jems/iterator/decorators/ChunkedTest.java
+++ b/src/test/java/org/dmfs/jems/iterator/decorators/ChunkedTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.iterator.decorators;
 
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.BrokenFragileMatcher.isBroken;

--- a/src/test/java/org/dmfs/jems/iterator/decorators/ClusteredTest.java
+++ b/src/test/java/org/dmfs/jems/iterator/decorators/ClusteredTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.iterator.decorators;
 
 import org.dmfs.iterators.EmptyIterator;
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.junit.Test;
 
 import java.util.Comparator;

--- a/src/test/java/org/dmfs/jems/iterator/decorators/MappedTest.java
+++ b/src/test/java/org/dmfs/jems/iterator/decorators/MappedTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.iterator.decorators;
 
 import org.dmfs.iterators.EmptyIterator;
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher.emptyIterator;

--- a/src/test/java/org/dmfs/jems/iterator/elementary/SeqTest.java
+++ b/src/test/java/org/dmfs/jems/iterator/elementary/SeqTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.iterator.elementary;
+
+import org.junit.Test;
+
+import static org.dmfs.jems.hamcrest.matchers.BrokenFragileMatcher.throwing;
+import static org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher.emptyIterator;
+import static org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher.iteratorOf;
+import static org.dmfs.jems.hamcrest.matchers.throwable.ThrowableMatcher.throwable;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test of {@link Seq}.
+ *
+ * @author Marten Gajda
+ */
+public class SeqTest
+{
+    @Test
+    public void testIterator() throws Exception
+    {
+        assertThat(Seq::new, emptyIterator());
+        assertThat(() -> new Seq<>("1"), iteratorOf("1"));
+        assertThat(() -> new Seq<>("1", "2", "3"), iteratorOf("1", "2", "3"));
+
+        assertThat(() -> new Seq<>(0, new String[] {}), emptyIterator());
+        assertThat(() -> new Seq<>(0, new String[] { "1", "2", "3" }), emptyIterator());
+        assertThat(() -> new Seq<>(1, new String[] { "1" }), iteratorOf("1"));
+        assertThat(() -> new Seq<>(1, new String[] { "1", "2", "3" }), iteratorOf("1"));
+        assertThat(() -> new Seq<>(3, new String[] { "1", "2", "3" }), iteratorOf("1", "2", "3"));
+
+        assertThat(() -> new Seq<>(1, new String[] {}), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+        assertThat(() -> new Seq<>(4, new String[] { "1", "2", "3" }), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+        assertThat(() -> new Seq<>(4, new String[] { "1" }), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+        assertThat(() -> new Seq<>(-1, new String[] {}), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+        assertThat(() -> new Seq<>(-1, new String[] { "1", "2", "3" }), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+        assertThat(() -> new Seq<>(-2, new String[] { "1" }), is(throwing(throwable(ArrayIndexOutOfBoundsException.class))));
+    }
+
+}

--- a/src/test/java/org/dmfs/jems/optional/adapters/FirstPresentTest.java
+++ b/src/test/java/org/dmfs/jems/optional/adapters/FirstPresentTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.optional.adapters;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher;
 import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.elementary.Present;

--- a/src/test/java/org/dmfs/jems/optional/adapters/FirstTest.java
+++ b/src/test/java/org/dmfs/jems/optional/adapters/FirstTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.optional.adapters;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.iterators.Filter;
 import org.dmfs.jems.predicate.Predicate;
 import org.junit.Test;

--- a/src/test/java/org/dmfs/jems/optional/adapters/NextPresentTest.java
+++ b/src/test/java/org/dmfs/jems/optional/adapters/NextPresentTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.optional.adapters;
 
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher;
 import org.dmfs.jems.optional.Optional;
 import org.dmfs.jems.optional.elementary.Present;

--- a/src/test/java/org/dmfs/jems/predicate/composite/AllOfTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/composite/AllOfTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.predicate.composite;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.predicate.Predicate;
 import org.dmfs.jems.predicate.elementary.Equals;
 import org.junit.Test;

--- a/src/test/java/org/dmfs/jems/predicate/composite/AnyOfTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/composite/AnyOfTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.predicate.composite;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.predicate.elementary.Equals;
 import org.junit.Test;
 

--- a/src/test/java/org/dmfs/jems/predicate/composite/NoneOfTest.java
+++ b/src/test/java/org/dmfs/jems/predicate/composite/NoneOfTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.predicate.composite;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.predicate.elementary.Equals;
 import org.junit.Test;
 

--- a/src/test/java/org/dmfs/jems/procedure/composite/BatchTest.java
+++ b/src/test/java/org/dmfs/jems/procedure/composite/BatchTest.java
@@ -19,7 +19,7 @@ package org.dmfs.jems.procedure.composite;
 
 import org.dmfs.iterables.EmptyIterable;
 import org.dmfs.iterables.SingletonIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.procedure.Procedure;
 import org.junit.Test;
 

--- a/src/test/java/org/dmfs/jems/single/elementary/CollectedTest.java
+++ b/src/test/java/org/dmfs/jems/single/elementary/CollectedTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.jems.single.elementary;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.junit.Test;
 
 import java.util.ArrayList;

--- a/src/test/java/org/dmfs/jems/single/elementary/DigestTest.java
+++ b/src/test/java/org/dmfs/jems/single/elementary/DigestTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.single.elementary;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.messagedigest.elementary.Md5;
 import org.dmfs.jems.single.Single;
 import org.junit.Test;

--- a/src/test/java/org/dmfs/jems/single/elementary/ReducedTest.java
+++ b/src/test/java/org/dmfs/jems/single/elementary/ReducedTest.java
@@ -19,7 +19,7 @@ package org.dmfs.jems.single.elementary;
 
 import org.dmfs.iterables.EmptyIterable;
 import org.dmfs.iterables.SingletonIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.function.BiFunction;
 import org.junit.Test;
 

--- a/src/test/java/org/dmfs/optional/FirstTest.java
+++ b/src/test/java/org/dmfs/optional/FirstTest.java
@@ -18,7 +18,7 @@
 package org.dmfs.optional;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.iterators.Filter;
 import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.dmfs.jems.predicate.Predicate;

--- a/src/test/java/org/dmfs/optional/adapters/FirstPresentTest.java
+++ b/src/test/java/org/dmfs/optional/adapters/FirstPresentTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.optional.adapters;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;

--- a/src/test/java/org/dmfs/optional/adapters/NextPresentTest.java
+++ b/src/test/java/org/dmfs/optional/adapters/NextPresentTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.optional.adapters;
 
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.dmfs.jems.hamcrest.matchers.AbsentMatcher;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;

--- a/src/test/java/org/dmfs/optional/iterable/OptionalIterableTest.java
+++ b/src/test/java/org/dmfs/optional/iterable/OptionalIterableTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.optional.iterable;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Present;
 import org.hamcrest.Matchers;

--- a/src/test/java/org/dmfs/optional/iterable/PresentValuesTest.java
+++ b/src/test/java/org/dmfs/optional/iterable/PresentValuesTest.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.optional.iterable;
 
-import org.dmfs.iterables.elementary.Seq;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;
 import org.dmfs.optional.Present;

--- a/src/test/java/org/dmfs/optional/iterator/PresentValuesTest.java
+++ b/src/test/java/org/dmfs/optional/iterator/PresentValuesTest.java
@@ -19,7 +19,7 @@ package org.dmfs.optional.iterator;
 
 import org.dmfs.iterators.EmptyIterator;
 import org.dmfs.iterators.SingletonIterator;
-import org.dmfs.iterators.elementary.Seq;
+import org.dmfs.jems.iterator.elementary.Seq;
 import org.dmfs.optional.Absent;
 import org.dmfs.optional.Optional;
 import org.dmfs.optional.Present;


### PR DESCRIPTION
This creates new `Seq` implementations (for both, the `Iterable` and the `Iterator`) in the jems package, which also take the number of elements to iterate. This allows to pass an array and iterate only the first few elements.