### PR TITLE
Add Matchers for Procedure, implements #259

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/procedure/ProcedureMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/procedure/ProcedureMatcher.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.procedure;
+
+import org.dmfs.jems.generator.Generator;
+import org.dmfs.jems.procedure.Procedure;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+
+/**
+ * A {@link Matcher} to test simple {@link Procedure}s.
+ * <pre><code>
+ * // simple case -> no mocked Ctor arguments
+ * assertThat(new Testee("1"), processes(()->arg, equalTo(...)));
+ * </code></pre>
+ */
+public final class ProcedureMatcher<Argument> extends TypeSafeDiagnosingMatcher<Procedure<? super Argument>>
+{
+    private final Generator<? extends Argument> mArgumentGenerator;
+    private final Matcher<? super Argument> mDelegate;
+
+
+    public static <Argument> Matcher<Procedure<? super Argument>> processes(Generator<? extends Argument> argumentGenerator, Matcher<? super Argument> delegate)
+    {
+        return new ProcedureMatcher<>(argumentGenerator, delegate);
+    }
+
+
+    public ProcedureMatcher(Generator<? extends Argument> argumentGenerator, Matcher<? super Argument> delegate)
+    {
+        mArgumentGenerator = argumentGenerator;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Procedure<? super Argument> item, Description mismatchDescription)
+    {
+        Argument argument = mArgumentGenerator.next();
+        item.process(argument);
+        if (!mDelegate.matches(argument))
+        {
+            mismatchDescription.appendText("processed argument ");
+            mDelegate.describeMismatch(argument, mismatchDescription);
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("processes ")
+                .appendValue(mArgumentGenerator.next())
+                .appendText(" to ")
+                .appendDescriptionOf(mDelegate);
+    }
+}

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/procedure/ProcedureMatcher2.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/procedure/ProcedureMatcher2.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.procedure;
+
+import org.dmfs.jems.function.Function;
+import org.dmfs.jems.generator.Generator;
+import org.dmfs.jems.procedure.Procedure;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+
+/**
+ * Usage like
+ * <pre><code>
+ *     // Procedure with single mocked ctor argument
+ *     assertThat(param -> new Testee(param, "x"), processes(()-> param, arg, equalTo(...)));
+ * </code></pre>
+ */
+public final class ProcedureMatcher2<Param, Argument>
+        extends TypeSafeDiagnosingMatcher<Function<? super Param, ? extends Procedure<? super Argument>>>
+{
+    private final Generator<Param> mParamGenerator;
+    private final Argument mArgument;
+    private final Matcher<? super Param> mDelegate;
+
+
+    public static <Param, Argument> Matcher<Function<? super Param, ? extends Procedure<? super Argument>>> processes(
+            Generator<Param> paramGenerator,
+            Argument argument,
+            Matcher<? super Param> delegate)
+    {
+        return new ProcedureMatcher2<>(paramGenerator, argument, delegate);
+    }
+
+
+    public ProcedureMatcher2(Generator<Param> paramGenerator, Argument argument, Matcher<? super Param> delegate)
+    {
+        mParamGenerator = paramGenerator;
+        mArgument = argument;
+        mDelegate = delegate;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(Function<? super Param, ? extends Procedure<? super Argument>> item, Description mismatchDescription)
+    {
+        Param param = mParamGenerator.next();
+        item.value(param).process(mArgument);
+        if (!mDelegate.matches(param))
+        {
+            mismatchDescription.appendText("processed parameter ");
+            mDelegate.describeMismatch(param, mismatchDescription);
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("processes ")
+                .appendValue(mParamGenerator.next())
+                .appendText(" with ")
+                .appendValue(mArgument)
+                .appendText(" to ")
+                .appendDescriptionOf(mDelegate);
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/procedure/ProcedureMatcher2Test.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/procedure/ProcedureMatcher2Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.procedure;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems.hamcrest.matchers.procedure.ProcedureMatcher2.processes;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link ProcedureMatcher2}.
+ */
+public class ProcedureMatcher2Test
+{
+    @Test
+    public void test()
+    {
+        assertThat(processes(ArrayList::new, "x", iteratesTo("x")),
+                allOf(
+                        matches(l -> l::add),
+                        mismatches(l -> argument -> l.add(argument + "2"), "processed parameter item 0: was \"x2\""),
+                        mismatches(l -> arg -> {
+                        }, "processed parameter No item matched: \"x\""),
+                        describesAs("processes <[]> with \"x\" to iterable containing [\"x\"]")));
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/procedure/ProcedureMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/procedure/ProcedureMatcherTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.procedure;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems.hamcrest.matchers.procedure.ProcedureMatcher.processes;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link ProcedureMatcher}.
+ */
+public class ProcedureMatcherTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(processes(ArrayList::new, iteratesTo("x")),
+                allOf(
+                        matches(l -> l.add("x")),
+                        mismatches(l -> l.add("y"), "processed argument item 0: was \"y\""),
+                        mismatches(l -> {
+                        }, "processed argument No item matched: \"x\""),
+                        describesAs("processes <[]> to iterable containing [\"x\"]")));
+    }
+}


### PR DESCRIPTION
This commit introduces two matchers for Procedures.