### PR TITLE
Add Mockito Mock Matcher, implements #261

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/mockito/MockInteractionMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/mockito/MockInteractionMatcher.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.mockito;
+
+import org.dmfs.iterables.EmptyIterable;
+import org.dmfs.jems.iterable.elementary.Seq;
+import org.dmfs.jems.procedure.Procedure;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.mockito.InOrder;
+
+import static org.mockito.Mockito.inOrder;
+
+
+/**
+ * A Matcher for interactions with Mockito mocks.
+ * <p>
+ * Note that, by design this matcher mutates the mock.
+ */
+public final class MockInteractionMatcher<T> extends TypeSafeDiagnosingMatcher<T>
+{
+    private final Iterable<? extends Procedure<? super T>> mTestProcedures;
+
+
+    public static <T> Matcher<T> notCalled()
+    {
+        return new MockInteractionMatcher<>(new EmptyIterable<>());
+    }
+
+
+    @SafeVarargs
+    public static <T> Matcher<T> calledInOrder(Procedure<? super T>... verifications)
+    {
+        return new MockInteractionMatcher<T>(new Seq<>(verifications));
+    }
+
+
+    public MockInteractionMatcher(Iterable<? extends Procedure<? super T>> mTestProcedures)
+    {
+        this.mTestProcedures = mTestProcedures;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(T item, Description mismatchDescription)
+    {
+        InOrder inOrder = inOrder(item);
+        try
+        {
+            for (Procedure<? super T> verification : mTestProcedures)
+            {
+                verification.process(inOrder.verify(item));
+            }
+            inOrder.verifyNoMoreInteractions();
+        }
+        catch (AssertionError e)
+        {
+            mismatchDescription.appendText(e.getMessage());
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description.appendText("mock is called in order");
+    }
+}

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/mockito/MockInteractionMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/mockito/MockInteractionMatcherTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.mockito;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems.hamcrest.matchers.mockito.MockInteractionMatcher.calledInOrder;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+
+/**
+ * Unit test for {@link MockInteractionMatcher}.
+ */
+public class MockInteractionMatcherTest
+{
+    @Test
+    public void test()
+    {
+        List<?> mockList1 = mock(List.class);
+        mockList1.isEmpty();
+        List<?> mockList2 = mock(List.class);
+
+        assertThat(calledInOrder(List::isEmpty),
+                allOf(
+                        matches(mockList1),
+                        mismatches(mockList2)
+                ));
+
+        assertThat(calledInOrder(Object::toString),
+                describesAs("mock is called in order"));
+    }
+}

--- a/src/test/java/org/dmfs/jems/procedure/composite/BatchTest.java
+++ b/src/test/java/org/dmfs/jems/procedure/composite/BatchTest.java
@@ -18,15 +18,16 @@
 package org.dmfs.jems.procedure.composite;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.SingletonIterable;
 import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.procedure.Procedure;
 import org.junit.Test;
 
+import static org.dmfs.jems.hamcrest.matchers.mockito.MockInteractionMatcher.calledInOrder;
+import static org.dmfs.jems.hamcrest.matchers.mockito.MockInteractionMatcher.notCalled;
+import static org.dmfs.jems.hamcrest.matchers.procedure.ProcedureMatcher2.processes;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 
 /**
@@ -36,38 +37,31 @@ import static org.mockito.Mockito.verifyZeroInteractions;
  */
 public class BatchTest
 {
-    @Test
-    public void testEmpty()
-    {
-        Procedure<Object> mock = mock(Procedure.class);
-        new Batch<>(mock).process(EmptyIterable.instance());
-        verifyZeroInteractions(mock);
-    }
-
 
     @Test
-    public void testSingle()
+    public void test()
     {
-        Procedure<Object> mock = mock(Procedure.class);
-        Object contentMock = new Object();
-        new Batch<>(mock).process(new SingletonIterable<>(contentMock));
-        verify(mock).process(contentMock);
-        verifyNoMoreInteractions(mock);
+        assertThat(Batch::new,
+                processes(
+                        () -> mock(Procedure.class),
+                        new EmptyIterable<>(),
+                        is(notCalled())
+                ));
+
+        assertThat(Batch::new,
+                processes(
+                        () -> mock(Procedure.class),
+                        new Seq<>("x"),
+                        is(calledInOrder(
+                                p -> p.process("x")))));
+
+        assertThat(Batch::new,
+                processes(
+                        () -> mock(Procedure.class),
+                        new Seq<>("x", "y", "z"),
+                        is(calledInOrder(
+                                p -> p.process("x"),
+                                p -> p.process("y"),
+                                p -> p.process("z")))));
     }
-
-
-    @Test
-    public void testMultiple()
-    {
-        Procedure<Object> mock = mock(Procedure.class);
-        Object contentMock1 = new Object();
-        Object contentMock2 = new Object();
-        Object contentMock3 = new Object();
-        new Batch<>(mock).process(new Seq<>(contentMock1, contentMock2, contentMock3));
-        verify(mock).process(contentMock1);
-        verify(mock).process(contentMock2);
-        verify(mock).process(contentMock3);
-        verifyNoMoreInteractions(mock);
-    }
-
 }

--- a/src/test/java/org/dmfs/jems/procedure/composite/ForEachTest.java
+++ b/src/test/java/org/dmfs/jems/procedure/composite/ForEachTest.java
@@ -18,80 +18,74 @@
 package org.dmfs.jems.procedure.composite;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.iterables.SingletonIterable;
 import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.optional.elementary.Absent;
 import org.dmfs.jems.optional.elementary.Present;
+import org.dmfs.jems.procedure.Procedure;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
-import static org.hamcrest.Matchers.emptyIterable;
+import static org.dmfs.jems.hamcrest.matchers.mockito.MockInteractionMatcher.calledInOrder;
+import static org.dmfs.jems.hamcrest.matchers.mockito.MockInteractionMatcher.notCalled;
+import static org.dmfs.jems.hamcrest.matchers.procedure.ProcedureMatcher.processes;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 
 /**
  * Unit test for {@link ForEach}.
  *
  * @author Marten Gajda
- * <p>
- * // TODO can we write that using a Matcher?
  */
 public class ForEachTest
 {
     @Test
-    public void testEmptyIterable()
+    public void testIterables()
     {
-        List<String> args = new ArrayList<>();
-        new ForEach<>(new EmptyIterable<String>()).process(args::add);
-        assertThat(args, is(emptyIterable()));
+        assertThat(
+                new ForEach<>(EmptyIterable.instance()),
+                processes(
+                        () -> (Procedure<? super Object>) mock(Procedure.class),
+                        is(notCalled())));
+        assertThat(
+                new ForEach<>(new Seq<>("x")),
+                processes(
+                        () -> (Procedure<? super String>) mock(Procedure.class),
+                        calledInOrder(p -> p.process("x"))));
+        assertThat(
+                new ForEach<>(new Seq<>("x", "y", "z")),
+                processes(
+                        () -> (Procedure<? super String>) mock(Procedure.class),
+                        calledInOrder(
+                                p -> p.process("x"),
+                                p -> p.process("y"),
+                                p -> p.process("z"))));
     }
 
 
     @Test
-    public void testSingletonIterable()
+    public void testOptional()
     {
-        List<String> args = new ArrayList<>();
-        new ForEach<>(new SingletonIterable<>("a")).process(args::add);
-        assertThat(args, iteratesTo("a"));
-    }
-
-
-    @Test
-    public void testIterable()
-    {
-        List<String> args = new ArrayList<>();
-        new ForEach<>(new Seq<>("a", "b", "c")).process(args::add);
-        assertThat(args, iteratesTo("a", "b", "c"));
-    }
-
-
-    @Test
-    public void testAbsentOptional()
-    {
-        List<String> args = new ArrayList<>();
-        new ForEach<>(new Absent<String>()).process(args::add);
-        assertThat(args, is(emptyIterable()));
-    }
-
-
-    @Test
-    public void testPresentOptional()
-    {
-        List<String> args = new ArrayList<>();
-        new ForEach<>(new Present<>("a")).process(args::add);
-        assertThat(args, iteratesTo("a"));
+        assertThat(
+                new ForEach<>(new Absent<>()),
+                processes(
+                        () -> (Procedure<? super Object>) mock(Procedure.class),
+                        is(notCalled())));
+        assertThat(
+                new ForEach<>(new Present<>("x")),
+                processes(
+                        () -> (Procedure<? super String>) mock(Procedure.class),
+                        calledInOrder(p -> p.process("x"))));
     }
 
 
     @Test
     public void testSingle()
     {
-        List<String> args = new ArrayList<>();
-        new ForEach<>(() -> "a").process(args::add);
-        assertThat(args, iteratesTo("a"));
+        assertThat(
+                new ForEach<>(() -> "x"),
+                processes(
+                        () -> (Procedure<? super String>) mock(Procedure.class),
+                        calledInOrder(p -> p.process("x"))));
     }
 }


### PR DESCRIPTION
Add a Matcher for simple interactions with a Mockito Mock and adjust two existing tests to utilize the new matcher.