### PR TITLE
Add FragileFunction, implements #231

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/BrokenFragileMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/BrokenFragileMatcher.java
@@ -32,7 +32,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
  */
 public final class BrokenFragileMatcher<E extends Throwable> extends TypeSafeDiagnosingMatcher<Fragile<?, E>>
 {
-    private final Matcher<E> mExceptionMatcher;
+    private final Matcher<? super E> mExceptionMatcher;
 
 
     public static <E extends Throwable> Matcher<Fragile<?, E>> throwing(Matcher<E> exceptionMatcher)
@@ -57,9 +57,9 @@ public final class BrokenFragileMatcher<E extends Throwable> extends TypeSafeDia
     }
 
 
-    public BrokenFragileMatcher(Matcher<E> mExceptionMatcher)
+    public BrokenFragileMatcher(Matcher<? super E> exceptionMatcher)
     {
-        this.mExceptionMatcher = mExceptionMatcher;
+        mExceptionMatcher = exceptionMatcher;
     }
 
 

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/function/FragileFunctionMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/function/FragileFunctionMatcher.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.function;
+
+import org.dmfs.jems.function.FragileFunction;
+import org.dmfs.jems.hamcrest.matchers.BrokenFragileMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import static org.dmfs.jems.hamcrest.matchers.LambdaMatcher.having;
+import static org.hamcrest.Matchers.is;
+
+
+/**
+ * A {@link Matcher} to test {@link FragileFunction}s.
+ */
+public final class FragileFunctionMatcher<Argument, Result, E extends Throwable> extends TypeSafeDiagnosingMatcher<FragileFunction<? super Argument, ? extends Result, E>>
+{
+    private final Argument mArgument;
+    private final Matcher<? super Result> mResultMatcher;
+
+
+    /**
+     * Returns a {@link Matcher} which verifies that the tested {@link FragileFunction} throws the given throwable to the given argument.
+     */
+    public static <Argument, Result, E extends Throwable> Matcher<FragileFunction<? super Argument, ? extends Result, E>> throwing(
+        Argument argument,
+        Matcher<E> throwableMatcher)
+    {
+        return having("value Fragile", testee -> () -> testee.value(argument), is(BrokenFragileMatcher.throwing(throwableMatcher)));
+    }
+
+
+    /**
+     * Returns a {@link Matcher} which verifies that the tested {@link FragileFunction} associates the given result to the given argument.
+     */
+    public static <Argument, Result, E extends Throwable> Matcher<FragileFunction<? super Argument, ? extends Result, E>> associates(Argument argument,
+                                                                                                                                     Result result)
+    {
+        return new FragileFunctionMatcher<>(argument, is(result));
+    }
+
+
+    /**
+     * Returns a {@link Matcher} which verifies that the tested {@link FragileFunction} associates a result satisfying the given {@link Matcher} to the given
+     * argument.
+     */
+    public static <Argument, Result, E extends Throwable> Matcher<FragileFunction<? super Argument, ? extends Result, E>> associates(Argument argument,
+                                                                                                                                     Matcher<? super Result> resultMatcher)
+    {
+        return new FragileFunctionMatcher<>(argument, resultMatcher);
+    }
+
+
+    public FragileFunctionMatcher(Argument mArgument, Matcher<? super Result> mResultMatcher)
+    {
+        this.mArgument = mArgument;
+        this.mResultMatcher = mResultMatcher;
+    }
+
+
+    @Override
+    protected boolean matchesSafely(FragileFunction<? super Argument, ? extends Result, E> item, Description mismatchDescription)
+    {
+        Result result = null;
+        try
+        {
+            result = item.value(mArgument);
+        }
+        catch (Throwable throwable)
+        {
+            mismatchDescription.appendText(String.format("threw %s for argument %s", throwable, mArgument));
+            return false;
+        }
+        if (!mResultMatcher.matches(result))
+        {
+            mismatchDescription.appendText(String.format("result for argument %s ", mArgument));
+            mResultMatcher.describeMismatch(result, mismatchDescription);
+            return false;
+        }
+        return true;
+    }
+
+
+    @Override
+    public void describeTo(Description description)
+    {
+        description
+            .appendText(String.format("result for argument %s ", mArgument))
+            .appendDescriptionOf(mResultMatcher);
+    }
+
+}

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/function/FunctionMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/function/FunctionMatcher.java
@@ -29,7 +29,9 @@ import static org.hamcrest.Matchers.is;
  * A {@link Matcher} to test {@link Function}s.
  *
  * @author Marten Gajda
+ * @deprecated in favor of {@link FragileFunctionMatcher}
  */
+@Deprecated
 public final class FunctionMatcher<Argument, Result> extends TypeSafeDiagnosingMatcher<Function<? super Argument, ? extends Result>>
 {
     private final Argument mArgument;
@@ -38,7 +40,10 @@ public final class FunctionMatcher<Argument, Result> extends TypeSafeDiagnosingM
 
     /**
      * Returns a {@link Matcher} which verifies that the tested {@link Function} associates the given result to the given argument.
+     *
+     * @deprecated in favor of {@link FragileFunctionMatcher#associates(Object, Object)}
      */
+    @Deprecated
     public static <Argument, Result> Matcher<Function<? super Argument, ? extends Result>> associates(Argument argument, Result result)
     {
         return new FunctionMatcher<>(argument, is(result));
@@ -48,7 +53,10 @@ public final class FunctionMatcher<Argument, Result> extends TypeSafeDiagnosingM
     /**
      * Returns a {@link Matcher} which verifies that the tested {@link Function} associates a result satisfying the given {@link Matcher} to the given
      * argument.
+     *
+     * @deprecated in favor of {@link FragileFunctionMatcher#associates(Object, Matcher)}.
      */
+    @Deprecated
     public static <Argument, Result> Matcher<Function<? super Argument, ? extends Result>> associates(Argument argument, Matcher<? super Result> resultMatcher)
     {
         return new FunctionMatcher<>(argument, resultMatcher);
@@ -80,8 +88,8 @@ public final class FunctionMatcher<Argument, Result> extends TypeSafeDiagnosingM
     public void describeTo(Description description)
     {
         description
-                .appendText(String.format("result for argument %s ", mArgument))
-                .appendDescriptionOf(mResultMatcher);
+            .appendText(String.format("result for argument %s ", mArgument))
+            .appendDescriptionOf(mResultMatcher);
     }
 
 }

--- a/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/function/FragileFunctionMatcherTest.java
+++ b/jems-testing/src/test/java/org/dmfs/jems/hamcrest/matchers/function/FragileFunctionMatcherTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems.hamcrest.matchers.function;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.dmfs.jems.hamcrest.matchers.function.FragileFunctionMatcher.associates;
+import static org.dmfs.jems.hamcrest.matchers.function.FragileFunctionMatcher.throwing;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.describesAs;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.matches;
+import static org.dmfs.jems.hamcrest.matchers.matcher.MatcherMatcher.mismatches;
+import static org.dmfs.jems.hamcrest.matchers.throwable.ThrowableMatcher.throwable;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Unit test for {@link FragileFunctionMatcher}.
+ */
+public class FragileFunctionMatcherTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new FragileFunctionMatcher<>(10, is(100)),
+            allOf(
+                matches(x -> x * x),
+                mismatches(x -> x, "result for argument 10 was <10>"),
+                mismatches(x -> {throw new RuntimeException();}, "threw java.lang.RuntimeException for argument 10"),
+                describesAs("result for argument 10 is <100>")));
+
+        assertThat(associates(10, is(100)),
+            allOf(
+                matches(x -> x * x),
+                mismatches(x -> x, "result for argument 10 was <10>"),
+                mismatches(x -> {throw new RuntimeException();}, "threw java.lang.RuntimeException for argument 10"),
+                describesAs("result for argument 10 is <100>")));
+
+        assertThat(associates(10, 100),
+            allOf(
+                matches(x -> x * x),
+                mismatches(x -> x, "result for argument 10 was <10>"),
+                mismatches(x -> {throw new RuntimeException();}, "threw java.lang.RuntimeException for argument 10"),
+                describesAs("result for argument 10 is <100>")));
+    }
+
+
+    @Test
+    public void testThrowing()
+    {
+        assertThat(throwing(10, throwable(instanceOf(IOException.class))),
+            allOf(
+                matches(x -> {throw new IOException();}),
+                mismatches(x -> x, "value Fragile Fragile was not broken"),
+                describesAs("value Fragile is broken Fragile throwing (an instance of java.io.IOException)")));
+    }
+
+}

--- a/src/main/java/org/dmfs/jems/fragile/decorators/Mapped.java
+++ b/src/main/java/org/dmfs/jems/fragile/decorators/Mapped.java
@@ -18,21 +18,21 @@
 package org.dmfs.jems.fragile.decorators;
 
 import org.dmfs.jems.fragile.Fragile;
-import org.dmfs.jems.function.Function;
+import org.dmfs.jems.function.FragileFunction;
 
 
 /**
- * A {@link Fragile} decorator which maps the value using a given {@link Function}.
- *
- * @author Marten Gajda
+ * A {@link Fragile} decorator which maps the value using a given {@link FragileFunction}.
  */
 public final class Mapped<From, To, E extends Throwable> implements Fragile<To, E>
 {
-    private final Function<From, To> mMapFunction;
-    private final Fragile<From, E> mDelegate;
+    private final FragileFunction<? super From, ? extends To, ? extends E> mMapFunction;
+    private final Fragile<? extends From, ? extends E> mDelegate;
 
 
-    public Mapped(Function<From, To> mapFunction, Fragile<From, E> delegate)
+    public Mapped(
+        FragileFunction<? super From, ? extends To, ? extends E> mapFunction,
+        Fragile<? extends From, ? extends E> delegate)
     {
         mMapFunction = mapFunction;
         mDelegate = delegate;

--- a/src/main/java/org/dmfs/jems/function/FragileFunction.java
+++ b/src/main/java/org/dmfs/jems/function/FragileFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 dmfs GmbH
+ * Copyright 2020 dmfs GmbH
  *
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +18,18 @@
 package org.dmfs.jems.function;
 
 /**
- * An unary function than can't throw checked Exceptions.
+ * An unary function that can throw a checked {@link Exception}.
  */
-public interface Function<Argument, Value> extends FragileFunction<Argument, Value, RuntimeException>
+public interface FragileFunction<Argument, Value, Error extends Throwable>
 {
+    /**
+     * Returns the value of this function at the given argument.
+     *
+     * @param argument
+     *     The argument of the function.
+     *
+     * @return The value of the function.
+     */
+    Value value(Argument argument) throws Error;
+
 }

--- a/src/test/java/org/dmfs/jems/fragile/decorators/MappedTest.java
+++ b/src/test/java/org/dmfs/jems/fragile/decorators/MappedTest.java
@@ -22,9 +22,11 @@ import org.dmfs.jems.fragile.elementary.Intact;
 import org.junit.Test;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 
-import static org.dmfs.jems.hamcrest.matchers.BrokenFragileMatcher.isBroken;
+import static org.dmfs.jems.hamcrest.matchers.BrokenFragileMatcher.throwing;
 import static org.dmfs.jems.hamcrest.matchers.IntactFragileMatcher.isIntact;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 
@@ -36,10 +38,15 @@ import static org.junit.Assert.assertThat;
 public class MappedTest
 {
     @Test
-    public void testValue() throws Exception
+    public void testValue()
     {
         assertThat(new Mapped<>(String::length, new Intact<>("abcde")), isIntact(5));
-        assertThat(new Mapped<>(String::length, new Broken<>(new FileNotFoundException())), isBroken(FileNotFoundException.class));
+        assertThat(new Mapped<>(String::length, new Broken<>(new FileNotFoundException())), is(throwing(FileNotFoundException.class)));
+        assertThat(new Mapped<>(s -> {throw new FileNotFoundException();}, new Intact<>("abcde")), is(throwing(FileNotFoundException.class)));
+        assertThat(new Mapped<>(
+                s -> {throw new IOException();},
+                new Broken<>(new FileNotFoundException())),
+            is(throwing(IOException.class)));
     }
 
 }


### PR DESCRIPTION
* Add a `FragileFunction` that can throw checked `Exception`s and a `Matcher` to test it.
* Change `Function` to extend `FragileFunction` throwing a `RuntimeException`
* Update `Mapped` `Fragile` to accept `FragileFunction`