### PR TITLE
Fix PairMatcher generic boundaries, fixes #291

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/IterableMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/IterableMatcher.java
@@ -37,14 +37,15 @@ public final class IterableMatcher
      * {@link Matcher} that matches when the provided matchers match with the actual {@link Iterable}s elements in the same order.
      */
     @Factory
-    public static <E> Matcher<Iterable<? extends E>> iteratesTo(Iterable<Matcher<E>> itemMatchers)
+    public static <E> Matcher<Iterable<? extends E>> iteratesTo(Iterable<? extends Matcher<? super E>> itemMatchers)
     {
+
         List<Matcher<? super E>> matchers = new ArrayList<>();
-        for (Matcher<E> itemMatcher : itemMatchers)
+        for (Matcher<? super E> itemMatcher : itemMatchers)
         {
             matchers.add(itemMatcher);
         }
-        return new IsIterableContainingInOrder<E>(matchers);
+        return new IsIterableContainingInOrder<>(matchers);
     }
 
 
@@ -64,7 +65,7 @@ public final class IterableMatcher
      */
     @SafeVarargs
     @Factory
-    public static <E> Matcher<Iterable<? extends E>> iteratesTo(Matcher<E>... itemMatchers)
+    public static <E> Matcher<Iterable<? extends E>> iteratesTo(Matcher<? super E>... itemMatchers)
     {
         return IsIterableContainingInOrder.contains(itemMatchers);
     }

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/PairMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/PairMatcher.java
@@ -30,13 +30,13 @@ import static org.hamcrest.CoreMatchers.equalTo;
  *
  * @author Gabor Keszthelyi
  */
-public final class PairMatcher<L, R> extends TypeSafeDiagnosingMatcher<Pair<L,R>>
+public final class PairMatcher<L, R> extends TypeSafeDiagnosingMatcher<Pair<? extends L, ? extends R>>
 {
-    private final Matcher<L> mLeftValueMatcher;
-    private final Matcher<R> mRightValueMatcher;
+    private final Matcher<? super L> mLeftValueMatcher;
+    private final Matcher<? super R> mRightValueMatcher;
 
 
-    public PairMatcher(Matcher<L> leftValueMatcher, Matcher<R> rightValueMatcher)
+    public PairMatcher(Matcher<? super L> leftValueMatcher, Matcher<? super R> rightValueMatcher)
     {
         mLeftValueMatcher = leftValueMatcher;
         mRightValueMatcher = rightValueMatcher;
@@ -44,7 +44,7 @@ public final class PairMatcher<L, R> extends TypeSafeDiagnosingMatcher<Pair<L,R>
 
 
     @Override
-    protected boolean matchesSafely(Pair actualPair, Description mismatchDescription)
+    protected boolean matchesSafely(Pair<? extends L, ? extends R> actualPair, Description mismatchDescription)
     {
         if (!mLeftValueMatcher.matches(actualPair.left()))
         {
@@ -75,7 +75,7 @@ public final class PairMatcher<L, R> extends TypeSafeDiagnosingMatcher<Pair<L,R>
     /**
      * Matcher that matches when the provided left and right value equals() to actual {@link Pair}s left and right value.
      */
-    public static <L, R> Matcher<Pair<L, R>> pair(L leftValue, R rightValue)
+    public static <L, R> Matcher<Pair<? extends L, ? extends R>> pair(L leftValue, R rightValue)
     {
         return new PairMatcher<>(equalTo(leftValue), equalTo(rightValue));
     }
@@ -84,7 +84,7 @@ public final class PairMatcher<L, R> extends TypeSafeDiagnosingMatcher<Pair<L,R>
     /**
      * Matcher that matches when the provided {@link Matcher}s for the left and right value match with the {@link Pair}s left and right value.
      */
-    public static <L, R> Matcher<Pair<L, R>> pair(Matcher<L> leftValueMatcher, Matcher<R> rightValueMatcher)
+    public static <L, R> Matcher<Pair<? extends L, ? extends R>> pair(Matcher<? super L> leftValueMatcher, Matcher<? super R> rightValueMatcher)
     {
         return new PairMatcher<>(leftValueMatcher, rightValueMatcher);
     }

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/iterator/IteratorMatcher.java
@@ -40,7 +40,7 @@ public final class IteratorMatcher<T> extends TypeSafeDiagnosingMatcher<Generato
 {
     public static final int HAS_NEXT_TEST_COUNT = 100;
     public static final int EXCEPTION_TEST_COUNT = 100;
-    private final Iterable<Matcher<T>> mElementMatchers;
+    private final Iterable<Matcher<? super T>> mElementMatchers;
 
 
     public static <T> Matcher<Generator<? extends Iterator<? extends T>>> emptyIterator()
@@ -56,20 +56,20 @@ public final class IteratorMatcher<T> extends TypeSafeDiagnosingMatcher<Generato
     }
 
 
-    public static <T> Matcher<Generator<? extends Iterator<? extends T>>> iteratorOf(Iterable<Matcher<T>> elementMatchers)
+    public static <T> Matcher<Generator<? extends Iterator<? extends T>>> iteratorOf(Iterable<Matcher<? super T>> elementMatchers)
     {
         return new IteratorMatcher<>(elementMatchers);
     }
 
 
     @SafeVarargs
-    public static <T> Matcher<Generator<? extends Iterator<? extends T>>> iteratorOf(Matcher<T>... elementMatchers)
+    public static <T> Matcher<Generator<? extends Iterator<? extends T>>> iteratorOf(Matcher<? super T>... elementMatchers)
     {
-        return new IteratorMatcher<>(new Seq<>(elementMatchers));
+        return new IteratorMatcher<T>(new Seq<>(elementMatchers));
     }
 
 
-    public IteratorMatcher(Iterable<Matcher<T>> mElementMatchers)
+    public IteratorMatcher(Iterable<Matcher<? super T>> mElementMatchers)
     {
         this.mElementMatchers = mElementMatchers;
     }
@@ -78,7 +78,7 @@ public final class IteratorMatcher<T> extends TypeSafeDiagnosingMatcher<Generato
     @Override
     protected boolean matchesSafely(Generator<? extends Iterator<? extends T>> item, Description mismatchDescription)
     {
-        Iterator<Matcher<T>> matcherIterator = mElementMatchers.iterator();
+        Iterator<Matcher<? super T>> matcherIterator = mElementMatchers.iterator();
         Iterator<? extends T> testee = item.next();
         int index = 0;
         while (testee.hasNext() && matcherIterator.hasNext())
@@ -108,7 +108,7 @@ public final class IteratorMatcher<T> extends TypeSafeDiagnosingMatcher<Generato
                 }
             }
             T next = testee.next();
-            Matcher<T> nextMatcher = matcherIterator.next();
+            Matcher<? super T> nextMatcher = matcherIterator.next();
             if (!nextMatcher.matches(next))
             {
                 nextMatcher.describeMismatch(next, mismatchDescription);

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/optional/AbsentMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/optional/AbsentMatcher.java
@@ -30,19 +30,19 @@ import java.util.NoSuchElementException;
  *
  * @author Marten Gajda
  */
-public final class AbsentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T>>
+public final class AbsentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<? extends T>>
 {
     /**
      * Creates a matcher that matches when the tested value is absent.
      */
     public static <T> AbsentMatcher<T> absent()
     {
-        return new AbsentMatcher<T>();
+        return new AbsentMatcher<>();
     }
 
 
     @Override
-    protected boolean matchesSafely(Optional<T> item, Description mismatchDescription)
+    protected boolean matchesSafely(Optional<? extends T> item, Description mismatchDescription)
     {
         if (item.isPresent())
         {

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/optional/PresentMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/optional/PresentMatcher.java
@@ -24,15 +24,17 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.core.IsAnything;
 import org.hamcrest.core.IsEqual;
 
+import static org.hamcrest.Matchers.equalTo;
+
 
 /**
  * A {@link Matcher} to match the presence and value of an {@link Optional}.
  *
  * @author Marten Gajda
  */
-public final class PresentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<T>>
+public final class PresentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<? extends T>>
 {
-    private final Matcher<T> mDelegate;
+    private final Matcher<? super T> mDelegate;
 
 
     public PresentMatcher()
@@ -47,7 +49,7 @@ public final class PresentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<
     }
 
 
-    public PresentMatcher(Matcher<T> delegate)
+    public PresentMatcher(Matcher<? super T> delegate)
     {
         mDelegate = delegate;
     }
@@ -61,18 +63,18 @@ public final class PresentMatcher<T> extends TypeSafeDiagnosingMatcher<Optional<
 
     public static <T> PresentMatcher<T> present(T expectedValue)
     {
-        return new PresentMatcher<>(expectedValue);
+        return new PresentMatcher<>(equalTo(expectedValue));
     }
 
 
-    public static <T> PresentMatcher<T> present(Matcher<T> delegate)
+    public static <T> PresentMatcher<T> present(Matcher<? super T> delegate)
     {
         return new PresentMatcher<>(delegate);
     }
 
 
     @Override
-    protected boolean matchesSafely(Optional<T> item, Description mismatchDescription)
+    protected boolean matchesSafely(Optional<? extends T> item, Description mismatchDescription)
     {
         if (!item.isPresent())
         {

--- a/src/main/java/org/dmfs/iterators/composite/PairZipped.java
+++ b/src/main/java/org/dmfs/iterators/composite/PairZipped.java
@@ -34,9 +34,9 @@ import java.util.Iterator;
 public final class PairZipped<Left, Right> extends DelegatingIterator<Pair<Left, Right>>
 {
 
-    public PairZipped(Iterator<Left> leftIterator, Iterator<Right> rightIterator)
+    public PairZipped(Iterator<? extends Left> leftIterator, Iterator<? extends Right> rightIterator)
     {
-        super(new Zipped<>(leftIterator, rightIterator, PairingFunction.<Left, Right>instance()));
+        super(new Zipped<>(leftIterator, rightIterator, PairingFunction.instance()));
     }
 
 }

--- a/src/main/java/org/dmfs/iterators/composite/Zipped.java
+++ b/src/main/java/org/dmfs/iterators/composite/Zipped.java
@@ -32,12 +32,15 @@ import java.util.Iterator;
  */
 public final class Zipped<Left, Right, Result> extends AbstractBaseIterator<Result>
 {
-    private final Iterator<Left> mLeft;
-    private final Iterator<Right> mRight;
-    private final BiFunction<Left, Right, Result> mFunction;
+    private final Iterator<? extends Left> mLeft;
+    private final Iterator<? extends Right> mRight;
+    private final BiFunction<? super Left, ? super Right, ? extends Result> mFunction;
 
 
-    public Zipped(Iterator<Left> left, Iterator<Right> right, BiFunction<Left, Right, Result> function)
+    public Zipped(
+        Iterator<? extends Left> left,
+        Iterator<? extends Right> right,
+        BiFunction<? super Left, ? super Right, ? extends Result> function)
     {
         mLeft = left;
         mRight = right;

--- a/src/main/java/org/dmfs/jems/iterable/composite/Diff.java
+++ b/src/main/java/org/dmfs/jems/iterable/composite/Diff.java
@@ -29,14 +29,17 @@ import java.util.Iterator;
  *
  * @author Marten Gajda
  */
-public final class Diff<Left, Right> implements Iterable<Pair<Optional<Left>, Optional<Right>>>
+public final class Diff<Left, Right> implements Iterable<Pair<? extends Optional<? extends Left>, ? extends Optional<? extends Right>>>
 {
-    private final Iterable<Left> mLefts;
-    private final Iterable<Right> mRights;
-    private final BiFunction<Left, Right, Integer> mComparatorFunction;
+    private final Iterable<? extends Left> mLefts;
+    private final Iterable<? extends Right> mRights;
+    private final BiFunction<? super Left, ? super Right, Integer> mComparatorFunction;
 
 
-    public Diff(Iterable<Left> lefts, Iterable<Right> rights, BiFunction<Left, Right, Integer> comparatorFunction)
+    public Diff(
+        Iterable<? extends Left> lefts,
+        Iterable<? extends Right> rights,
+        BiFunction<? super Left, ? super Right, Integer> comparatorFunction)
     {
         mLefts = lefts;
         mRights = rights;
@@ -45,7 +48,7 @@ public final class Diff<Left, Right> implements Iterable<Pair<Optional<Left>, Op
 
 
     @Override
-    public Iterator<Pair<Optional<Left>, Optional<Right>>> iterator()
+    public Iterator<Pair<? extends Optional<? extends Left>, ? extends Optional<? extends Right>>> iterator()
     {
         return new org.dmfs.jems.iterator.composite.Diff<>(mLefts.iterator(), mRights.iterator(), mComparatorFunction);
     }

--- a/src/main/java/org/dmfs/jems/iterator/composite/Diff.java
+++ b/src/main/java/org/dmfs/jems/iterator/composite/Diff.java
@@ -36,17 +36,19 @@ import java.util.NoSuchElementException;
  *
  * @author Marten Gajda
  */
-public final class Diff<Left, Right> extends AbstractBaseIterator<Pair<Optional<Left>, Optional<Right>>>
+public final class Diff<Left, Right> extends AbstractBaseIterator<Pair<? extends Optional<? extends Left>, ? extends Optional<? extends Right>>>
 {
-    private final Iterator<Left> mLefts;
-    private final Iterator<Right> mRights;
-    private final BiFunction<Left, Right, Integer> mComparatorFunction;
+    private final Iterator<? extends Left> mLefts;
+    private final Iterator<? extends Right> mRights;
+    private final BiFunction<? super Left, ? super Right, Integer> mComparatorFunction;
 
-    private Optional<Left> mNextLeft;
-    private Optional<Right> mNextRight;
+    private Optional<? extends Left> mNextLeft;
+    private Optional<? extends Right> mNextRight;
 
 
-    public Diff(Iterator<Left> leftIterator, Iterator<Right> rightIterator, BiFunction<Left, Right, Integer> comparatorFunction)
+    public Diff(Iterator<? extends Left> leftIterator,
+                Iterator<? extends Right> rightIterator,
+                BiFunction<? super Left, ? super Right, Integer> comparatorFunction)
     {
         mLefts = leftIterator;
         mRights = rightIterator;
@@ -64,7 +66,7 @@ public final class Diff<Left, Right> extends AbstractBaseIterator<Pair<Optional<
 
 
     @Override
-    public Pair<Optional<Left>, Optional<Right>> next()
+    public Pair<? extends Optional<? extends Left>, ? extends Optional<? extends Right>> next()
     {
         if (!hasNext())
         {
@@ -74,14 +76,14 @@ public final class Diff<Left, Right> extends AbstractBaseIterator<Pair<Optional<
         if (!mNextLeft.isPresent())
         {
             // no further elements on the left, advance the right side
-            Optional<Right> right = mNextRight;
+            Optional<? extends Right> right = mNextRight;
             mNextRight = new Next<>(mRights);
             return new RightSidedPair<>(right);
         }
         if (!mNextRight.isPresent())
         {
             // no further elements on the right, advance the left side
-            Optional<Left> left = mNextLeft;
+            Optional<? extends Left> left = mNextLeft;
             mNextLeft = new Next<>(mLefts);
             return new LeftSidedPair<>(left);
         }
@@ -90,7 +92,7 @@ public final class Diff<Left, Right> extends AbstractBaseIterator<Pair<Optional<
         if (result < 0)
         {
             // return the smaller result, the left one in this case
-            Optional<Left> nextLeft = mNextLeft;
+            Optional<? extends Left> nextLeft = mNextLeft;
             // advance left
             mNextLeft = new Next<>(mLefts);
             return new LeftSidedPair<>(nextLeft);
@@ -98,15 +100,15 @@ public final class Diff<Left, Right> extends AbstractBaseIterator<Pair<Optional<
         if (result > 0)
         {
             // return the smaller result, the right one in this case
-            Optional<Right> nextRight = mNextRight;
+            Optional<? extends Right> nextRight = mNextRight;
             // advance right
             mNextRight = new Next<>(mRights);
             return new RightSidedPair<>(nextRight);
         }
 
         // both sides are equal
-        Optional<Left> nextLeft = mNextLeft;
-        Optional<Right> nextRight = mNextRight;
+        Optional<? extends Left> nextLeft = mNextLeft;
+        Optional<? extends Right> nextRight = mNextRight;
         // advance both
         mNextLeft = new Next<>(mLefts);
         mNextRight = new Next<>(mRights);

--- a/src/main/java/org/dmfs/jems/pair/elementary/LeftSidedPair.java
+++ b/src/main/java/org/dmfs/jems/pair/elementary/LeftSidedPair.java
@@ -28,7 +28,7 @@ import static org.dmfs.optional.Absent.absent;
  *
  * @author Marten Gajda
  */
-public final class LeftSidedPair<Left, Right> implements Pair<Left, Optional<Right>>
+public final class LeftSidedPair<Left, Right> implements Pair<Left, Optional<? extends Right>>
 {
     private final Left mLeft;
 
@@ -47,7 +47,7 @@ public final class LeftSidedPair<Left, Right> implements Pair<Left, Optional<Rig
 
 
     @Override
-    public Optional<Right> right()
+    public Optional<? extends Right> right()
     {
         return absent();
     }

--- a/src/main/java/org/dmfs/jems/pair/elementary/RightSidedPair.java
+++ b/src/main/java/org/dmfs/jems/pair/elementary/RightSidedPair.java
@@ -28,7 +28,7 @@ import static org.dmfs.optional.Absent.absent;
  *
  * @author Marten Gajda
  */
-public final class RightSidedPair<Left, Right> implements Pair<Optional<Left>, Right>
+public final class RightSidedPair<Left, Right> implements Pair<Optional<? extends Left>, Right>
 {
     private final Right mRight;
 
@@ -40,7 +40,7 @@ public final class RightSidedPair<Left, Right> implements Pair<Optional<Left>, R
 
 
     @Override
-    public Optional<Left> left()
+    public Optional<? extends Left> left()
     {
         return absent();
     }

--- a/src/test/java/org/dmfs/jems/iterable/composite/DiffTest.java
+++ b/src/test/java/org/dmfs/jems/iterable/composite/DiffTest.java
@@ -18,8 +18,9 @@
 package org.dmfs.jems.iterable.composite;
 
 import org.dmfs.iterables.EmptyIterable;
-import org.dmfs.jems.iterable.elementary.Seq;
 import org.dmfs.jems.function.BiFunction;
+import org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher;
+import org.dmfs.jems.iterable.elementary.Seq;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.IterableMatcher.iteratesTo;
@@ -41,86 +42,86 @@ public class DiffTest
     {
         // empty Iterables result in an empty Diff
         assertThat(new Diff<>(EmptyIterable.<String>instance(), EmptyIterable.<String>instance(), new TestFunction()),
-                emptyIterable());
+            emptyIterable());
 
         // one empty side, means this side is always absent in the result
         assertThat(new Diff<>(new Seq<>("a"), EmptyIterable.<String>instance(), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(absent()))));
+            iteratesTo(
+                pair(is(present("a")), is(absent()))));
         assertThat(new Diff<>(new Seq<>("a", "b"), EmptyIterable.<String>instance(), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(absent())),
-                        pair(is(present("b")), is(absent()))));
+            iteratesTo(
+                pair(is(present("a")), is(absent())),
+                pair(is(present("b")), is(absent()))));
         assertThat(new Diff<>(new Seq<>("a", "b", "c"), EmptyIterable.<String>instance(), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(absent())),
-                        pair(is(present("b")), is(absent())),
-                        pair(is(present("c")), is(absent()))));
+            iteratesTo(
+                pair(is(present("a")), is(absent())),
+                pair(is(present("b")), is(absent())),
+                pair(is(present("c")), is(absent()))));
 
         assertThat(new Diff<>(EmptyIterable.<String>instance(), new Seq<>("a"), new TestFunction()),
-                iteratesTo(
-                        pair(is(absent()), is(present("a")))));
+            iteratesTo(
+                pair(is(absent()), is(present("a")))));
         assertThat(new Diff<>(EmptyIterable.<String>instance(), new Seq<>("a", "b"), new TestFunction()),
-                iteratesTo(
-                        pair(is(absent()), is(present("a"))),
-                        pair(is(absent()), is(present("b")))));
+            iteratesTo(
+                pair(is(absent()), is(present("a"))),
+                pair(is(absent()), is(present("b")))));
         assertThat(new Diff<>(EmptyIterable.<String>instance(), new Seq<>("a", "b", "c"), new TestFunction()),
-                iteratesTo(
-                        pair(is(absent()), is(present("a"))),
-                        pair(is(absent()), is(present("b"))),
-                        pair(is(absent()), is(present("c")))));
+            iteratesTo(
+                pair(is(absent()), is(present("a"))),
+                pair(is(absent()), is(present("b"))),
+                pair(is(absent()), is(present("c")))));
 
         // equals Iterables result in pairs with both sides present
         assertThat(new Diff<>(new Seq<>("a"), new Seq<>("a"), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(present("a")))));
+            iteratesTo(
+                pair(is(present("a")), is(present("a")))));
         assertThat(new Diff<>(new Seq<>("a", "b"), new Seq<>("a", "b"), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(present("a"))),
-                        pair(is(present("b")), is(present("b")))));
+            iteratesTo(
+                pair(is(present("a")), is(present("a"))),
+                pair(is(present("b")), is(present("b")))));
         assertThat(new Diff<>(new Seq<>("a", "b", "c"), new Seq<>("a", "b", "c"), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(present("a"))),
-                        pair(is(present("b")), is(present("b"))),
-                        pair(is(present("c")), is(present("c")))));
+            iteratesTo(
+                pair(is(present("a")), is(present("a"))),
+                pair(is(present("b")), is(present("b"))),
+                pair(is(present("c")), is(present("c")))));
 
         // various different Iterables
         assertThat(new Diff<>(new Seq<>("a"), new Seq<>("b"), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(absent())),
-                        pair(is(absent()), is(present("b")))));
+            iteratesTo(
+                pair(is(present("a")), is(AbsentMatcher.<String>absent())),
+                pair(is(absent()), is(present("b")))));
         assertThat(new Diff<>(new Seq<>("a"), new Seq<>("a", "b"), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(present("a"))),
-                        pair(is(absent()), is(present("b")))));
+            iteratesTo(
+                pair(is(present("a")), is(present("a"))),
+                pair(is(absent()), is(present("b")))));
         assertThat(new Diff<>(new Seq<>("a", "b"), new Seq<>("b"), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(absent())),
-                        pair(is(present("b")), is(present("b")))));
+            iteratesTo(
+                pair(is(present("a")), is(absent())),
+                pair(is(present("b")), is(present("b")))));
 
         assertThat(new Diff<>(new Seq<>("a", "c"), new Seq<>("a", "b", "c"), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(present("a"))),
-                        pair(is(absent()), is(present("b"))),
-                        pair(is(present("c")), is(present("c")))));
+            iteratesTo(
+                pair(is(present("a")), is(present("a"))),
+                pair(is(absent()), is(present("b"))),
+                pair(is(present("c")), is(present("c")))));
 
         assertThat(new Diff<>(new Seq<>("a", "b", "c"), new Seq<>("a", "c"), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(present("a"))),
-                        pair(is(present("b")), is(absent())),
-                        pair(is(present("c")), is(present("c")))));
+            iteratesTo(
+                pair(is(present("a")), is(present("a"))),
+                pair(is(present("b")), is(absent())),
+                pair(is(present("c")), is(present("c")))));
 
         assertThat(new Diff<>(new Seq<>("b"), new Seq<>("a", "b", "c"), new TestFunction()),
-                iteratesTo(
-                        pair(is(absent()), is(present("a"))),
-                        pair(is(present("b")), is(present("b"))),
-                        pair(is(absent()), is(present("c")))));
+            iteratesTo(
+                pair(is(absent()), is(present("a"))),
+                pair(is(present("b")), is(present("b"))),
+                pair(is(absent()), is(present("c")))));
 
         assertThat(new Diff<>(new Seq<>("a", "b", "c"), new Seq<>("b"), new TestFunction()),
-                iteratesTo(
-                        pair(is(present("a")), is(absent())),
-                        pair(is(present("b")), is(present("b"))),
-                        pair(is(present("c")), is(absent()))));
+            iteratesTo(
+                pair(is(present("a")), is(absent())),
+                pair(is(present("b")), is(present("b"))),
+                pair(is(present("c")), is(absent()))));
     }
 
 

--- a/src/test/java/org/dmfs/jems/iterator/composite/DiffTest.java
+++ b/src/test/java/org/dmfs/jems/iterator/composite/DiffTest.java
@@ -18,6 +18,7 @@
 package org.dmfs.jems.iterator.composite;
 
 import org.dmfs.iterators.EmptyIterator;
+import org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher;
 import org.dmfs.jems.iterator.elementary.Seq;
 import org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher;
 import org.dmfs.jems.optional.Optional;
@@ -25,6 +26,7 @@ import org.dmfs.jems.pair.Pair;
 import org.junit.Test;
 
 import static org.dmfs.jems.hamcrest.matchers.PairMatcher.pair;
+import static org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher.emptyIterator;
 import static org.dmfs.jems.hamcrest.matchers.iterator.IteratorMatcher.iteratorOf;
 import static org.dmfs.jems.hamcrest.matchers.optional.AbsentMatcher.absent;
 import static org.dmfs.jems.hamcrest.matchers.optional.PresentMatcher.present;
@@ -43,26 +45,26 @@ public class DiffTest
     public void test()
     {
         assertThat(() -> new Diff<>(new EmptyIterator<>(), new EmptyIterator<>(), (l, r) -> 0),
-                is(IteratorMatcher.<Pair<Optional<Object>, Optional<Object>>>emptyIterator()));
+                is(emptyIterator()));
 
-        assertThat(() -> new Diff<>(new Seq<>("a", "a", "b", "c"), new EmptyIterator<>(), (l, r) -> l.compareTo(r)),
-                is(IteratorMatcher.<Pair<Optional<String>, Optional<String>>>iteratorOf(
+        assertThat(() -> new Diff<>(new Seq<>("a", "a", "b", "c"), new EmptyIterator<>(), String::compareTo),
+                is(iteratorOf(
                         pair(is(present("a")), is(absent())),
                         pair(is(present("a")), is(absent())),
                         pair(is(present("b")), is(absent())),
                         pair(is(present("c")), is(absent())))));
 
-        assertThat(() -> new Diff<>(new EmptyIterator<>(), new Seq<>("a", "a", "b", "c"), (l, r) -> l.compareTo(r)),
-                is(IteratorMatcher.<Pair<Optional<String>, Optional<String>>>iteratorOf(
+        assertThat(() -> new Diff<>(new EmptyIterator<>(), new Seq<>("a", "a", "b", "c"), String::compareTo),
+                is(iteratorOf(
                         pair(is(absent()), is(present("a"))),
                         pair(is(absent()), is(present("a"))),
                         pair(is(absent()), is(present("b"))),
                         pair(is(absent()), is(present("c")))
                 )));
 
-        assertThat(() -> new Diff<>(new Seq<>("1", "2", "3", "4"), new Seq<>("a", "a", "b", "c"), (l, r) -> l.compareTo(r)),
+        assertThat(() -> new Diff<>(new Seq<>("1", "2", "3", "4"), new Seq<>("a", "a", "b", "c"), String::compareTo),
                 is(iteratorOf(
-                        pair(is(present("1")), is(absent())),
+                        pair(is(present("1")), is(AbsentMatcher.<String>absent())),
                         pair(is(present("2")), is(absent())),
                         pair(is(present("3")), is(absent())),
                         pair(is(present("4")), is(absent())),
@@ -72,7 +74,7 @@ public class DiffTest
                         pair(is(absent()), is(present("c")))
                 )));
 
-        assertThat(() -> new Diff<>(new Seq<>("a", "b", "b", "c"), new Seq<>("a", "a", "b", "c"), (l, r) -> l.compareTo(r)),
+        assertThat(() -> new Diff<>(new Seq<>("a", "b", "b", "c"), new Seq<>("a", "a", "b", "c"), String::compareTo),
                 is(iteratorOf(
                         pair(is(present("a")), is(present("a"))),
                         pair(is(absent()), is(present("a"))),
@@ -81,7 +83,7 @@ public class DiffTest
                         pair(is(present("c")), is(present("c")))
                 )));
 
-        assertThat(() -> new Diff<>(new Seq<>("b", "b", "c"), new Seq<>("a", "a", "b"), (l, r) -> l.compareTo(r)),
+        assertThat(() -> new Diff<>(new Seq<>("b", "b", "c"), new Seq<>("a", "a", "b"), String::compareTo),
                 is(iteratorOf(
                         pair(is(absent()), is(present("a"))),
                         pair(is(absent()), is(present("a"))),


### PR DESCRIPTION
This required a couple of other fixes to generic arguments to make it work.