### PR TITLE
Publish untagged revisions as Snapshots, implements #293

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,13 @@ sourceCompatibility = 1.8
 def gitVersion = { ->
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags'
+        commandLine 'git', 'describe', '--tags', '--always', '--dirty'
         standardOutput = stdout
     }
-    return stdout.toString().trim()
+    def version = stdout.toString().trim()
+    // TODO: a SNAPSHOT should have the minor number increased by one (and the patch number reset to 0) https://github.com/dmfs/jems/issues/295
+    // TODO: the git version format is not fully compliant to semantic versioning 2.0.0 https://github.com/dmfs/jems/issues/295
+    return version.contains('-') ? version + '-SNAPSHOT' : version
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 RELEASE_REPOSITORY=https://oss.sonatype.org/service/local/staging/deploy/maven2
+SNAPSHOT_REPOSITORY=https://oss.sonatype.org/content/repositories/snapshots/
 POM_DEVELOPER_ID=dmfs
 POM_DEVELOPER_NAME=Marten Gajda
 POM_DEVELOPER_EMAIL=marten@dmfs.org

--- a/publish.gradle
+++ b/publish.gradle
@@ -16,8 +16,8 @@ if (project.hasProperty('SONATYPE_USERNAME') && project.hasProperty('SONATYPE_PA
     publishing {
         repositories {
             maven {
-                name 'release'
-                url RELEASE_REPOSITORY
+                name project.version.toString().endsWith("-SNAPSHOT") ? 'snapshot' : 'release'
+                url project.version.toString().endsWith("-SNAPSHOT") ? SNAPSHOT_REPOSITORY : RELEASE_REPOSITORY
                 credentials {
                     username SONATYPE_USERNAME
                     password SONATYPE_PASSWORD


### PR DESCRIPTION
As of this commit the snapshot version number is not compatible with semantic versioning as it doesn't increment the minor version of the snapshot. That's left to a subsequent story (#295).