### PR TITLE
Fix a couple of Generic Arguments, fixes #305

### DIFF
--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/BrokenFragileMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/BrokenFragileMatcher.java
@@ -30,20 +30,20 @@ import static org.hamcrest.CoreMatchers.instanceOf;
  *
  * @author Marten Gajda
  */
-public final class BrokenFragileMatcher<E extends Throwable> extends TypeSafeDiagnosingMatcher<Fragile<?, ?>>
+public final class BrokenFragileMatcher extends TypeSafeDiagnosingMatcher<Fragile<?, ?>>
 {
-    private final Matcher<? super E> mExceptionMatcher;
+    private final Matcher<? super Throwable> mExceptionMatcher;
 
 
-    public static <E extends Throwable> Matcher<Fragile<?, ?>> throwing(Matcher<E> exceptionMatcher)
+    public static Matcher<Fragile<?, ?>> throwing(Matcher<? super Throwable> exceptionMatcher)
     {
-        return new BrokenFragileMatcher<>(exceptionMatcher);
+        return new BrokenFragileMatcher(exceptionMatcher);
     }
 
 
-    public static <E extends Throwable> Matcher<Fragile<?, ?>> throwing(Class<E> exceptionClass)
+    public static Matcher<Fragile<?, ?>> throwing(Class<? extends Throwable> exceptionClass)
     {
-        return new BrokenFragileMatcher<>(instanceOf(exceptionClass));
+        return new BrokenFragileMatcher(instanceOf(exceptionClass));
     }
 
 
@@ -51,13 +51,13 @@ public final class BrokenFragileMatcher<E extends Throwable> extends TypeSafeDia
      * @deprecated in favour of {@link #throwing(Class)} (for the better name).
      */
     @Deprecated
-    public static <E extends Throwable> Matcher<Fragile<?, ?>> isBroken(Class<E> exceptionClass)
+    public static Matcher<Fragile<?, ?>> isBroken(Class<? extends Throwable> exceptionClass)
     {
-        return new BrokenFragileMatcher<>(instanceOf(exceptionClass));
+        return new BrokenFragileMatcher(instanceOf(exceptionClass));
     }
 
 
-    public BrokenFragileMatcher(Matcher<? super E> exceptionMatcher)
+    public BrokenFragileMatcher(Matcher<? super Throwable> exceptionMatcher)
     {
         mExceptionMatcher = exceptionMatcher;
     }

--- a/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/function/FragileFunctionMatcher.java
+++ b/jems-testing/src/main/java/org/dmfs/jems/hamcrest/matchers/function/FragileFunctionMatcher.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.is;
 /**
  * A {@link Matcher} to test {@link FragileFunction}s.
  */
-public final class FragileFunctionMatcher<Argument, Result, E extends Throwable> extends TypeSafeDiagnosingMatcher<FragileFunction<? super Argument, ? extends Result, ?>>
+public final class FragileFunctionMatcher<Argument, Result> extends TypeSafeDiagnosingMatcher<FragileFunction<? super Argument, ? extends Result, ?>>
 {
     private final Argument mArgument;
     private final Matcher<? super Result> mResultMatcher;
@@ -39,9 +39,9 @@ public final class FragileFunctionMatcher<Argument, Result, E extends Throwable>
     /**
      * Returns a {@link Matcher} which verifies that the tested {@link FragileFunction} throws the given throwable to the given argument.
      */
-    public static <Argument, Result, E extends Throwable> Matcher<FragileFunction<? super Argument, ? extends Result, ?>> throwing(
+    public static <Argument, Result> Matcher<FragileFunction<? super Argument, ? extends Result, ?>> throwing(
         Argument argument,
-        Matcher<E> throwableMatcher)
+        Matcher<? super Throwable> throwableMatcher)
     {
         return having("value Fragile", testee -> () -> testee.value(argument), is(BrokenFragileMatcher.throwing(throwableMatcher)));
     }
@@ -50,7 +50,7 @@ public final class FragileFunctionMatcher<Argument, Result, E extends Throwable>
     /**
      * Returns a {@link Matcher} which verifies that the tested {@link FragileFunction} associates the given result to the given argument.
      */
-    public static <Argument, Result, E extends Throwable> Matcher<FragileFunction<? super Argument, ? extends Result, ?>> associates(Argument argument,
+    public static <Argument, Result> Matcher<FragileFunction<? super Argument, ? extends Result, ?>> associates(Argument argument,
                                                                                                                                      Result result)
     {
         return new FragileFunctionMatcher<>(argument, is(result));
@@ -61,7 +61,7 @@ public final class FragileFunctionMatcher<Argument, Result, E extends Throwable>
      * Returns a {@link Matcher} which verifies that the tested {@link FragileFunction} associates a result satisfying the given {@link Matcher} to the given
      * argument.
      */
-    public static <Argument, Result, E extends Throwable> Matcher<FragileFunction<? super Argument, ? extends Result, ?>> associates(Argument argument,
+    public static <Argument, Result> Matcher<FragileFunction<? super Argument, ? extends Result, ?>> associates(Argument argument,
                                                                                                                                      Matcher<? super Result> resultMatcher)
     {
         return new FragileFunctionMatcher<>(argument, resultMatcher);

--- a/src/main/java/org/dmfs/jems/iterable/decorators/Sorted.java
+++ b/src/main/java/org/dmfs/jems/iterable/decorators/Sorted.java
@@ -17,7 +17,7 @@
 
 package org.dmfs.jems.iterable.decorators;
 
-import org.dmfs.jems.single.elementary.Reduced;
+import org.dmfs.jems.single.elementary.Collected;
 
 import java.util.Comparator;
 import java.util.Iterator;
@@ -32,10 +32,10 @@ import java.util.TreeSet;
 public final class Sorted<T> implements Iterable<T>
 {
     private final Iterable<T> mDelegate;
-    private final Comparator<T> mComparator;
+    private final Comparator<? super T> mComparator;
 
 
-    public Sorted(Comparator<T> comparator, Iterable<T> delegate)
+    public Sorted(Comparator<? super T> comparator, Iterable<T> delegate)
     {
         mDelegate = delegate;
         mComparator = comparator;
@@ -45,9 +45,6 @@ public final class Sorted<T> implements Iterable<T>
     @Override
     public Iterator<T> iterator()
     {
-        return new Reduced<>(new TreeSet<>(mComparator), (r, v) -> {
-            r.add(v);
-            return r;
-        }, mDelegate).value().iterator();
+        return new Collected<>(() -> new TreeSet<>(mComparator), mDelegate).value().iterator();
     }
 }

--- a/src/main/java/org/dmfs/jems/single/Single.java
+++ b/src/main/java/org/dmfs/jems/single/Single.java
@@ -32,5 +32,6 @@ public interface Single<T> extends Fragile<T, RuntimeException>
      *
      * @return The value.
      */
+    @Override
     T value();
 }

--- a/src/main/java/org/dmfs/jems/single/elementary/Digest.java
+++ b/src/main/java/org/dmfs/jems/single/elementary/Digest.java
@@ -35,7 +35,7 @@ import java.util.Locale;
  */
 public final class Digest implements Single<byte[]>
 {
-    private final Generator<MessageDigest> mMessageDigestGenerator;
+    private final Generator<? extends MessageDigest> mMessageDigestGenerator;
     private final Iterable<? extends Fragile<byte[], ? extends RuntimeException>> mParts;
 
 
@@ -94,7 +94,7 @@ public final class Digest implements Single<byte[]>
 
 
     public Digest(
-        Generator<MessageDigest> messageDigestGenerator,
+        Generator<? extends MessageDigest> messageDigestGenerator,
         byte[]... parts)
     {
         this(messageDigestGenerator, new Mapped<>(part -> () -> part, new Seq<>(parts)));
@@ -102,7 +102,7 @@ public final class Digest implements Single<byte[]>
 
 
     public Digest(
-        Generator<MessageDigest> messageDigestGenerator,
+        Generator<? extends MessageDigest> messageDigestGenerator,
         CharSequence... parts)
     {
         this(messageDigestGenerator, "UTF-8", parts);
@@ -110,7 +110,7 @@ public final class Digest implements Single<byte[]>
 
 
     public Digest(
-        Generator<MessageDigest> messageDigestGenerator,
+        Generator<? extends MessageDigest> messageDigestGenerator,
         final String encoding,
         CharSequence... parts)
     {
@@ -133,7 +133,7 @@ public final class Digest implements Single<byte[]>
 
     @SafeVarargs
     public Digest(
-        Generator<MessageDigest> messageDigestGenerator,
+        Generator<? extends MessageDigest> messageDigestGenerator,
         Fragile<byte[], ? extends RuntimeException>... parts)
     {
         this(messageDigestGenerator, new Seq<>(parts));
@@ -141,7 +141,7 @@ public final class Digest implements Single<byte[]>
 
 
     public Digest(
-        Generator<MessageDigest> messageDigestGenerator,
+        Generator<? extends MessageDigest> messageDigestGenerator,
         Iterable<? extends Fragile<byte[], ? extends RuntimeException>> parts)
     {
         mMessageDigestGenerator = messageDigestGenerator;

--- a/src/main/java/org/dmfs/jems/single/elementary/Reduced.java
+++ b/src/main/java/org/dmfs/jems/single/elementary/Reduced.java
@@ -38,7 +38,9 @@ public final class Reduced<Value, Result> implements Single<Result>
      * @deprecated in favor of {@link Reduced#Reduced(Generator, BiFunction, Iterable)}.
      */
     @Deprecated
-    public Reduced(Result initialValue, BiFunction<? super Result, ? super Value, ? extends Result> accumulatorFunction, Iterable<? extends Value> iterable)
+    public Reduced(Result initialValue,
+                   BiFunction<? super Result, ? super Value, ? extends Result> accumulatorFunction,
+                   Iterable<? extends Value> iterable)
     {
         this(() -> initialValue, accumulatorFunction, iterable);
     }


### PR DESCRIPTION
Strictly spoken this is a breaking change because BrokenFragileMatcher is no longer generic and using it directly would break now. However, one should only use the static methods and they are, thanks to type inference, still being used the same way.