### PR TITLE
Reintroduce SingleFunction, fixes #311

### DIFF
--- a/src/main/java/org/dmfs/jems2/function/SingleFunction.java
+++ b/src/main/java/org/dmfs/jems2/function/SingleFunction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems2.function;
+
+import org.dmfs.jems2.Function;
+import org.dmfs.jems2.Single;
+
+
+/**
+ * A {@link Function} which produces {@link Single}s of its arguments.
+ */
+public final class SingleFunction<T> implements Function<T, Single<T>>
+{
+    private static final Function<?, ?> INSTANCE = new SingleFunction<>();
+
+
+    @SuppressWarnings("unchecked")
+    public static <V> Function<V, Single<V>> toSingle()
+    {
+        return (Function<V, Single<V>>) INSTANCE;
+    }
+
+
+    @Override
+    public Single<T> value(T t)
+    {
+        return () -> t;
+    }
+}

--- a/src/main/java/org/dmfs/jems2/single/Digest.java
+++ b/src/main/java/org/dmfs/jems2/single/Digest.java
@@ -28,6 +28,8 @@ import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.util.Locale;
 
+import static org.dmfs.jems2.function.SingleFunction.toSingle;
+
 
 /**
  * A {@link Single} of a byte array which represents the digested value of the given input data.
@@ -42,7 +44,7 @@ public final class Digest implements Single<byte[]>
         Generator<? extends MessageDigest> messageDigestGenerator,
         byte[]... parts)
     {
-        this(messageDigestGenerator, new Mapped<>(part -> () -> part, new Seq<>(parts)));
+        this(messageDigestGenerator, new Mapped<>(toSingle(), new Seq<>(parts)));
     }
 
 

--- a/src/test/java/org/dmfs/jems2/function/SingleFunctionTest.java
+++ b/src/test/java/org/dmfs/jems2/function/SingleFunctionTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems2.function;
+
+import org.junit.Test;
+
+import static org.dmfs.jems2.function.SingleFunction.toSingle;
+import static org.dmfs.jems2.hamcrest.matchers.function.FragileFunctionMatcher.associates;
+import static org.dmfs.jems2.hamcrest.matchers.single.SingleMatcher.hasValue;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test {@link SingleFunction}.
+ */
+public class SingleFunctionTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(new SingleFunction<>(), associates("1", hasValue("1")));
+        assertThat(toSingle(), associates("a", hasValue("a")));
+    }
+}


### PR DESCRIPTION
Looks like there is an issue with the generic argument inference in Java
12 in the class Digest.
By introducing a SingleFunction we can fix this.