### PR TITLE
Add method to create mocks in an expression #318

### DIFF
--- a/jems2-testing/src/main/java/org/dmfs/jems2/mockito/Mock.java
+++ b/jems2-testing/src/main/java/org/dmfs/jems2/mockito/Mock.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2021 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems2.mockito;
+
+import org.dmfs.jems2.*;
+import org.dmfs.jems2.function.Unchecked;
+import org.dmfs.jems2.iterable.Seq;
+import org.dmfs.jems2.mockito.doubles.TestDoubles;
+import org.dmfs.jems2.procedure.Composite;
+import org.dmfs.jems2.single.Reduced;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.Stubber;
+
+import static org.mockito.Mockito.*;
+
+
+/**
+ * A container of static methods for creating mocks in a single expression.
+ */
+public final class Mock
+{
+    /**
+     * Return a mock of the given class. This takes a couple of {@link Procedure}s to set up the mock in a single expression.
+     * <p>
+     * Example
+     *
+     * <pre>{@code
+     * Foo fooMock = mock(Foo.class,
+     *     with(Foo::bar, returning("foobar")),
+     *     with(f->f.baz(123), returning("foobaz123")));
+     * }</pre>
+     * <p>
+     * Note, in contrast to {@link Mockito#mock(Class)}, mocks returned by this method fail with an {@link AssertionError}
+     * when a non-mocked method is called.
+     */
+    @SafeVarargs
+    public static <T> T mock(Class<T> clazz, Procedure<? super T>... methods)
+    {
+        T result = TestDoubles.failingMock(clazz);
+        new Composite<>(methods).process(result);
+        return result;
+    }
+
+
+    /**
+     * Returns a {@link Procedure} which configures a mock by setting the expectation on a method call.
+     * The result of this is supposed to be passed to {@link #mock(Class, Procedure[])}.
+     */
+    @SafeVarargs
+    public static <T, V> Procedure<T> with(
+        FragileFunction<? super T, ? extends V, ? extends Throwable> methodCall,
+        StubGenerator<? extends V> stubGenerator,
+        StubGenerator<? extends V>... stubGenerators)
+    {
+        return mock -> new Unchecked<>(methodCall).value(
+            new Reduced<>(stubGenerator, (stubber, function) -> function.value(stubber), new Seq<>(stubGenerators)).value().when(mock));
+    }
+
+
+    /**
+     * Returns a {@link Procedure} which configures a mock by setting the expectation on a void method call.
+     * The result of this is supposed to be passed to {@link #mock(Class, Procedure[])}.
+     */
+    @SafeVarargs
+    public static <T, V> Procedure<T> withVoid(
+        FragileProcedure<? super T, ? extends Throwable> methodCall,
+        StubGenerator<? extends V> stubGenerator,
+        StubGenerator<? extends V>... stubGenerators)
+    {
+        return mock ->
+            new org.dmfs.jems2.single.Unchecked<>(
+                () -> {
+                    methodCall.process(
+                        new Reduced<>(stubGenerator, (stubber, function) -> function.value(stubber), new Seq<>(stubGenerators)).value().when(mock));
+                    return null;
+                }).value();
+    }
+
+
+    /**
+     * Returns a {@link StubGenerator} that configures a {@link Stubber} to return the given values in the given order.
+     *
+     * @see Stubber#doReturn(Object, Object...)
+     */
+    @SafeVarargs
+    public static <T> StubGenerator<T> returning(T value, T... values)
+    {
+        return new StubGenerator<T>()
+        {
+            @Override
+            public Stubber value(Stubber stubber)
+            {
+                return stubber.doReturn(value, (Object[]) values);
+            }
+
+
+            @Override
+            public Stubber next()
+            {
+                return doReturn(value, (Object[]) values);
+            }
+        };
+    }
+
+
+    /**
+     * Returns a {@link StubGenerator} that configures a {@link Stubber} to throw the given {@link Throwable}s.
+     *
+     * @see Stubber#doThrow(Throwable...)
+     */
+    public static <T> StubGenerator<T> throwing(Throwable... exception)
+    {
+        return new StubGenerator<T>()
+        {
+            @Override
+            public Stubber value(Stubber stubber)
+            {
+                return stubber.doThrow(exception);
+            }
+
+
+            @Override
+            public Stubber next()
+            {
+                return doThrow(exception);
+            }
+        };
+    }
+
+
+    /**
+     * Returns a {@link StubGenerator} that configures a {@link Stubber} to answer with the given {@link Answer}.
+     *
+     * @see Stubber#doAnswer(Answer)
+     */
+    public static <T> StubGenerator<T> answering(Answer<T> answer)
+    {
+        return new StubGenerator<T>()
+        {
+            @Override
+            public Stubber value(Stubber stubber)
+            {
+                return stubber.doAnswer(answer);
+            }
+
+
+            @Override
+            public Stubber next()
+            {
+                return doAnswer(answer);
+            }
+        };
+    }
+
+
+    /**
+     * Returns a {@link StubGenerator} that configures a {@link Stubber} do nothing.
+     *
+     * @see Stubber#doNothing()
+     */
+    public static <T> StubGenerator<T> doingNothing()
+    {
+        return new StubGenerator<T>()
+        {
+            @Override
+            public Stubber value(Stubber stubber)
+            {
+                return stubber.doNothing();
+            }
+
+
+            @Override
+            public Stubber next()
+            {
+                return doNothing();
+            }
+        };
+    }
+
+
+    /**
+     * A type that combines a {@link Stubber} {@link Generator} and {@link Function}
+     */
+    public interface StubGenerator<T> extends Generator<Stubber>, Function<Stubber, Stubber>
+    {
+
+    }
+}

--- a/jems2-testing/src/test/java/org/dmfs/jems2/mockito/MockTest.java
+++ b/jems2-testing/src/test/java/org/dmfs/jems2/mockito/MockTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems2.mockito;
+
+import org.dmfs.jems2.*;
+import org.dmfs.jems2.hamcrest.matchers.fragile.BrokenFragileMatcher;
+import org.dmfs.jems2.hamcrest.matchers.function.FragileFunctionMatcher;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.dmfs.jems2.hamcrest.matchers.LambdaMatcher.having;
+import static org.dmfs.jems2.hamcrest.matchers.function.FragileFunctionMatcher.associates;
+import static org.dmfs.jems2.hamcrest.matchers.generatable.GeneratableMatcher.startsWith;
+import static org.dmfs.jems2.hamcrest.matchers.optional.PresentMatcher.present;
+import static org.dmfs.jems2.hamcrest.matchers.procedure.ProcedureMatcher.processes;
+import static org.dmfs.jems2.hamcrest.matchers.throwable.ThrowableMatcher.throwable;
+import static org.dmfs.jems2.mockito.Mock.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assert.assertThat;
+
+
+public class MockTest
+{
+    @Test
+    public void testFailingMock()
+    {
+        assertThat((Single<?>) mock(Single.class), is(BrokenFragileMatcher.throwing(AssertionError.class)));
+
+        assertThat((Function<Object, ?>) mock(Function.class),
+            having(f -> () -> f.value(new Object()), is(BrokenFragileMatcher.throwing(AssertionError.class))));
+
+        assertThat((Procedure<Object>) mock(Procedure.class),
+            having(f -> () -> {
+                f.process(new Object());
+                return null;
+            }, is(BrokenFragileMatcher.throwing(AssertionError.class))));
+    }
+
+
+    @Test
+    public void testMockReturning()
+    {
+        assertThat(
+            () -> mock(Generator.class, with(Generator::next, returning("1", "2", "3"), returning("4"), returning("5"))),
+            startsWith("1", "2", "3", "4", "5", "5", "5"));
+
+        assertThat((Optional<String>)
+                mock(Optional.class,
+                    with(Optional::value, returning("1")),
+                    with(Optional::isPresent, returning(true))),
+            is(present("1")));
+
+        assertThat((Function<String, String>)
+                mock(Function.class,
+                    with(f -> f.value("1"), returning("one")),
+                    with(f -> f.value("2"), returning("two")),
+                    with(f -> f.value("3"), returning("three"))),
+            allOf(
+                associates("1", "one"),
+                associates("2", "two"),
+                associates("3", "three")));
+
+    }
+
+
+    @Test
+    public void testMockThrowing()
+    {
+        assertThat((Fragile<?, ?>)
+                mock(Fragile.class, with(Fragile::value,
+                    throwing(new IOException()))),
+            is(BrokenFragileMatcher.throwing(IOException.class)));
+
+        assertThat((Function<String, String>)
+                mock(Function.class,
+                    with(f -> f.value("1"), returning("one")),
+                    with(f -> f.value("2"), throwing(new IllegalArgumentException())),
+                    with(f -> f.value("3"), returning("three"))),
+            allOf(
+                associates("1", "one"),
+                FragileFunctionMatcher.throwing("2", throwable(IllegalArgumentException.class)),
+                associates("3", "three")));
+    }
+
+
+    @Test
+    public void testMockAnswering()
+    {
+        assertThat(
+            () -> mock(Generator.class, with(Generator::next, answering(invocation -> "1"), answering(invocation -> "2"))),
+            startsWith("1", "2"));
+    }
+
+
+    @Test
+    public void testMockDoingNothing()
+    {
+        assertThat((Procedure<String>) mock(Procedure.class,
+            withVoid(p -> p.process("123"), doingNothing(), doingNothing(), throwing(new IllegalArgumentException()))),
+            allOf(
+                processes(() -> "123", is("123")),
+                processes(() -> "123", is("123")),
+                having(p -> () -> {
+                    p.process("123");
+                    return null;
+                }, is(BrokenFragileMatcher.throwing(IllegalArgumentException.class)))));
+    }
+}


### PR DESCRIPTION
This commit adds means to create simple mocks in a single expression,
similar to how Mockito works in Kotlin.