### PR TITLE
Fix removal of duplicates by Sorted, fixes #328

### DIFF
--- a/src/main/java/org/dmfs/jems2/iterable/Sorted.java
+++ b/src/main/java/org/dmfs/jems2/iterable/Sorted.java
@@ -19,9 +19,10 @@ package org.dmfs.jems2.iterable;
 
 import org.dmfs.jems2.single.Collected;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.TreeSet;
+import java.util.List;
 
 
 /**
@@ -43,6 +44,8 @@ public final class Sorted<T> implements Iterable<T>
     @Override
     public Iterator<T> iterator()
     {
-        return new Collected<>(() -> new TreeSet<>(mComparator), mDelegate).value().iterator();
+        List<T> result = new Collected<>(ArrayList::new, mDelegate).value();
+        result.sort(mComparator);
+        return result.iterator();
     }
 }

--- a/src/test/java/org/dmfs/jems2/iterable/AscendingTest.java
+++ b/src/test/java/org/dmfs/jems2/iterable/AscendingTest.java
@@ -36,5 +36,6 @@ public class AscendingTest
         assertThat(new Ascending<String>(new Seq<>()), is(emptyIterable()));
         assertThat(new Ascending<>(new Seq<>("z")), iteratesTo("z"));
         assertThat(new Ascending<>(new Seq<>("z", "x", "y")), iteratesTo("x", "y", "z"));
+        assertThat(new Ascending<>(new Seq<>("z", "x", "y", "z", "x", "y")), iteratesTo("x", "x", "y", "y", "z", "z"));
     }
 }

--- a/src/test/java/org/dmfs/jems2/iterable/DescendingTest.java
+++ b/src/test/java/org/dmfs/jems2/iterable/DescendingTest.java
@@ -36,5 +36,6 @@ public class DescendingTest
         assertThat(new Descending<String>(new Seq<>()), is(emptyIterable()));
         assertThat(new Descending<>(new Seq<>("z")), iteratesTo("z"));
         assertThat(new Descending<>(new Seq<>("x", "y", "z")), iteratesTo("z", "y", "x"));
+        assertThat(new Descending<>(new Seq<>("x", "y", "z", "x", "y", "z")), iteratesTo("z", "z", "y", "y", "x", "x"));
     }
 }

--- a/src/test/java/org/dmfs/jems2/iterable/SortedTest.java
+++ b/src/test/java/org/dmfs/jems2/iterable/SortedTest.java
@@ -38,5 +38,7 @@ public class SortedTest
         assertThat(new Sorted<>(Comparator.naturalOrder(), new EmptyIterable<String>()), is(emptyIterable()));
         assertThat(new Sorted<>(Comparator.naturalOrder(), new Seq<>(7, 4, 1, 3, 6, 9)), iteratesTo(1, 3, 4, 6, 7, 9));
         assertThat(new Sorted<>(Comparator.reverseOrder(), new Seq<>(7, 4, 1, 3, 6, 9)), iteratesTo(9, 7, 6, 4, 3, 1));
+        assertThat(new Sorted<>(Comparator.naturalOrder(), new Seq<>(7, 1, 4, 1, 3, 6, 3, 9)), iteratesTo(1, 1, 3, 3, 4, 6, 7, 9));
+
     }
 }


### PR DESCRIPTION
The TreeSet we were using before (like any Set) dropped duplicate
values. By replacing it with a List we can sort it preserving duplicate
values.