### PR TITLE
Expanded for Optionals

### DIFF
--- a/src/main/java/org/dmfs/jems2/iterable/Expanded.java
+++ b/src/main/java/org/dmfs/jems2/iterable/Expanded.java
@@ -18,6 +18,7 @@
 package org.dmfs.jems2.iterable;
 
 import org.dmfs.jems2.Function;
+import org.dmfs.jems2.Optional;
 
 
 /**
@@ -27,6 +28,12 @@ import org.dmfs.jems2.Function;
  */
 public final class Expanded<T> extends DelegatingIterable<T>
 {
+    public <V> Expanded(Function<? super V, ? extends Iterable<? extends T>> function, Optional<V> delegate)
+    {
+        super(new Joined<>(new org.dmfs.jems2.optional.Mapped<>(function, delegate)));
+    }
+
+
     public <V> Expanded(Function<? super V, ? extends Iterable<? extends T>> function, Iterable<V> delegate)
     {
         super(new Joined<>(new Mapped<>(function, delegate)));

--- a/src/test/java/org/dmfs/jems2/iterable/ExpandedTest.java
+++ b/src/test/java/org/dmfs/jems2/iterable/ExpandedTest.java
@@ -18,10 +18,12 @@
 package org.dmfs.jems2.iterable;
 
 import org.dmfs.jems2.Function;
+import org.dmfs.jems2.optional.Present;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.dmfs.jems2.mockito.doubles.TestDoubles.dummy;
+import static org.dmfs.jems2.optional.Absent.absent;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
@@ -33,13 +35,26 @@ public class ExpandedTest
 {
 
     @Test
-    public void test()
+    public void testIterable()
     {
         Function<Object, Iterable<Object>> dummyFunction = dummy(Function.class);
         assertThat(new Expanded<>(dummyFunction, EmptyIterable.emptyIterable()), Matchers.emptyIterable());
         assertThat(new Expanded<>(
                 s -> new Seq<>(s + "1", s + "2", s + "3"),
                 new Seq<>("a", "b", "c")
+            ),
+            contains("a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3"));
+    }
+
+
+    @Test
+    public void testOptional()
+    {
+        Function<Object, Iterable<Object>> dummyFunction = dummy(Function.class);
+        assertThat(new Expanded<>(dummyFunction, absent()), Matchers.emptyIterable());
+        assertThat(new Expanded<>(
+                Seq::new,
+                new Present<>(new String[] { "a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3" })
             ),
             contains("a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3"));
     }


### PR DESCRIPTION
Add a convenince contructor that expands an Optional into an Iterable.