### PR TITLE
Add OptionalComparator GreaterAbsent

### DIFF
--- a/src/main/java/org/dmfs/jems2/comparator/GreaterAbsent.java
+++ b/src/main/java/org/dmfs/jems2/comparator/GreaterAbsent.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems2.comparator;
+
+import org.dmfs.jems2.Optional;
+
+import java.util.Comparator;
+
+
+/**
+ * A {@link Comparator} for {@link Optional} values. This is primarily meant to be used with {@link OptionalComparator} if
+ * an absent value is supposed to be larger than a present value.
+ */
+public final class GreaterAbsent<V> extends DelegatingComparator<Optional<? extends V>>
+{
+    public GreaterAbsent(Comparator<? super Optional<? extends V>> delegate)
+    {
+        super((l, r) -> l.isPresent() != r.isPresent()
+            ? l.isPresent() ? -1 : 1
+            : delegate.compare(l, r));
+    }
+}

--- a/src/main/java/org/dmfs/jems2/comparator/OptionalComparator.java
+++ b/src/main/java/org/dmfs/jems2/comparator/OptionalComparator.java
@@ -29,7 +29,7 @@ import java.util.Comparator;
 /**
  * A {@link Comparator} for {@link Optional} values.
  * <p>
- * Absent values are always "smaller" than present values.
+ * Absent values are always "smaller" than present values. Decorate this with {@link GreaterAbsent} to reverse this behavior.
  */
 public final class OptionalComparator<V> implements Comparator<Optional<? extends V>>
 {

--- a/src/test/java/org/dmfs/jems2/comparator/GreaterAbsentTest.java
+++ b/src/test/java/org/dmfs/jems2/comparator/GreaterAbsentTest.java
@@ -1,0 +1,60 @@
+
+/*
+ * Copyright 2021 dmfs GmbH
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dmfs.jems2.comparator;
+
+import org.dmfs.jems2.optional.Present;
+import org.junit.Test;
+
+import static java.util.Comparator.naturalOrder;
+import static org.dmfs.jems2.optional.Absent.absent;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+
+public class GreaterAbsentTest
+{
+    @Test
+    public void test()
+    {
+        assertThat(
+            new GreaterAbsent<>(new OptionalComparator<>(naturalOrder())).compare(absent(), absent()),
+            is(equalTo(0)));
+
+        assertThat(
+            new GreaterAbsent<Integer>(new OptionalComparator<>(naturalOrder())).compare(new Present<>(1), absent()),
+            is(lessThan(0)));
+
+        assertThat(
+            new GreaterAbsent<Integer>(new OptionalComparator<>(naturalOrder())).compare(absent(), new Present<>(1)),
+            is(greaterThan(0)));
+
+        assertThat(
+            new GreaterAbsent<Integer>(new OptionalComparator<>(naturalOrder())).compare(new Present<>(1), new Present<>(1)),
+            is(equalTo(0)));
+
+        assertThat(
+            new GreaterAbsent<Integer>(new OptionalComparator<>(naturalOrder())).compare(new Present<>(1), new Present<>(2)),
+            is(lessThan(0)));
+
+        assertThat(
+            new GreaterAbsent<Integer>(new OptionalComparator<>(naturalOrder())).compare(new Present<>(2), new Present<>(1)),
+            is(greaterThan(0)));
+    }
+
+}


### PR DESCRIPTION
This decorator changes the default behavior of OptionalComparator to
consider absent values smaller than present values.
implements #337