### PR TITLE
Named mock, closes #365

### DIFF
--- a/jems2-testing/src/main/java/org/dmfs/jems2/mockito/Mock.java
+++ b/jems2-testing/src/main/java/org/dmfs/jems2/mockito/Mock.java
@@ -47,7 +47,7 @@ public final class Mock
      * }</pre>
      * <p>
      * Note, in contrast to {@link Mockito#mock(Class)}, mocks returned by this method fail with an {@link AssertionError}
-     * when a non-mocked method is called.
+     * when a non-mocked method (other than {@link Object#hashCode()}, {@link Object#equals(Object)} and {@link Object#toString()}) is called.
      */
     @SafeVarargs
     public static <T> T mock(Class<T> clazz, Procedure<? super T>... methods)
@@ -55,6 +55,30 @@ public final class Mock
         T result = TestDoubles.failingMock(clazz);
         new Composite<>(methods).process(result);
         return result;
+    }
+
+
+    /**
+     * Return a named mock of the given class. The name is returned by the {@link Object#toString()} method of the resulting class.
+     * This takes a couple of {@link Procedure}s to set up the mock in a single expression.
+     * <p>
+     * Example
+     *
+     * <pre>{@code
+     * Foo fooMock = mock("My Foo", Foo.class,
+     *     with(Foo::bar, returning("foobar")),
+     *     with(f->f.baz(123), returning("foobaz123")));
+     * }</pre>
+     * <p>
+     * Note, in contrast to {@link Mockito#mock(Class)}, mocks returned by this method fail with an {@link AssertionError}
+     * when a non-mocked method (other than {@link Object#hashCode()}, {@link Object#equals(Object)} and {@link Object#toString()}) is called.
+     *
+     * @see #mock(Class, Procedure[])
+     */
+    @SafeVarargs
+    public static <T> T mock(String name, Class<T> clazz, Procedure<? super T>... methods)
+    {
+        return update(mock(clazz, with(Object::toString, returning(name))), methods);
     }
 
 

--- a/jems2-testing/src/main/java/org/dmfs/jems2/mockito/answers/FailAnswer.java
+++ b/jems2-testing/src/main/java/org/dmfs/jems2/mockito/answers/FailAnswer.java
@@ -30,8 +30,12 @@ public final class FailAnswer implements Answer<Object>
 
 
     @Override
-    public Object answer(InvocationOnMock invocation)
+    public Object answer(InvocationOnMock invocation) throws NoSuchMethodException
     {
+        if (invocation.getMethod().equals(Object.class.getMethod("toString")))
+        {
+            return "Mock of " + invocation.getMock().getClass() + " (" + invocation.getMock().hashCode() + ")";
+        }
         throw new AssertionError("Unexpected invocation: " + invocation);
     }
 }

--- a/jems2-testing/src/test/java/org/dmfs/jems2/mockito/MockTest.java
+++ b/jems2-testing/src/test/java/org/dmfs/jems2/mockito/MockTest.java
@@ -21,6 +21,7 @@ import org.dmfs.jems2.*;
 import org.dmfs.jems2.hamcrest.matchers.fragile.BrokenFragileMatcher;
 import org.dmfs.jems2.hamcrest.matchers.function.FragileFunctionMatcher;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 
@@ -34,6 +35,7 @@ import static org.dmfs.jems2.mockito.Mock.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasToString;
 
 
 public class MockTest
@@ -76,7 +78,23 @@ public class MockTest
                 associates("1", "one"),
                 associates("2", "two"),
                 associates("3", "three")));
+    }
 
+
+    @Test
+    public void testNamedMock()
+    {
+
+        assertThat((Function<String, String>)
+                mock("My Function", Function.class,
+                    with(f -> f.value("1"), returning("one")),
+                    with(f -> f.value("2"), returning("two")),
+                    with(f -> f.value("3"), returning("three"))),
+            allOf(
+                associates("1", "one"),
+                associates("2", "two"),
+                associates("3", "three"),
+                hasToString("My Function")));
     }
 
 

--- a/jems2-testing/src/test/java/org/dmfs/jems2/mockito/answers/FailAnswerTest.java
+++ b/jems2-testing/src/test/java/org/dmfs/jems2/mockito/answers/FailAnswerTest.java
@@ -32,9 +32,43 @@ import static org.mockito.Mockito.mock;
 public class FailAnswerTest
 {
     @Test
-    public void test()
+    public void testAnyMethod()
     {
-        assertThat(() -> new FailAnswer().answer(mock(InvocationOnMock.class, invocation -> {
+        assertThat(() -> {
+            try
+            {
+                return new FailAnswer().answer(mock(InvocationOnMock.class, invocation -> {
+                    if ("getMethod".equals(invocation.getMethod().getName()))
+                    {
+                        return Object.class.getMethod("equals", Object.class);
+                    }
+                    if ("toString".equals(invocation.getMethod().getName()))
+                    {
+                        return "invocationName";
+                    }
+                    throw new RuntimeException("Unexpected call on mock object");
+                }));
+            }
+            catch (NoSuchMethodException e)
+            {
+                throw new RuntimeException(e);
+            }
+        }, is(throwing(AssertionError.class)));
+    }
+
+
+    @Test
+    public void testToString() throws Throwable
+    {
+        assertThat(new FailAnswer().answer(mock(InvocationOnMock.class, invocation -> {
+            if ("getMethod".equals(invocation.getMethod().getName()))
+            {
+                return Object.class.getMethod("toString");
+            }
+            if ("getMock".equals(invocation.getMethod().getName()))
+            {
+                return "123";
+            }
             if (!"toString".equals(invocation.getMethod().getName()))
             {
                 throw new RuntimeException("Unexpected call on mock object");
@@ -43,6 +77,7 @@ public class FailAnswerTest
             {
                 return "invocationName";
             }
-        })), is(throwing(AssertionError.class)));
+        })), is("Mock of class java.lang.String (48690)"));
     }
+
 }


### PR DESCRIPTION
Provide a `mock` method that takes the `String` to be returned by `toString()` of the mock instance.